### PR TITLE
fix(ui): make Delete Channels button's disabled state clear

### DIFF
--- a/app/templates/admin/sources.html
+++ b/app/templates/admin/sources.html
@@ -247,6 +247,7 @@
     .btn-danger:hover { background: var(--error, #e05252); color: white; }
     .btn-confirm { background: var(--danger-border); color: white; }
     .btn-confirm:hover { background: var(--danger-border); }
+    .btn-confirm:disabled { opacity: 0.4; cursor: not-allowed; }
 
     .dash-actions { display: flex; gap: 0.4rem; }
     .dash-actions .btn { flex: 1; text-align: center; font-size: 0.72rem; font-weight: 600; line-height: 1.3; padding: 0.35rem 0.4rem; }

--- a/app/templates/admin/sources.html
+++ b/app/templates/admin/sources.html
@@ -892,7 +892,7 @@
   <div class="modal-overlay" id="cleanup-modal" onclick="closeCleanupModal(event)">
     <div class="modal" onclick="event.stopPropagation()" style="max-width:460px">
       <h2>Clean Up Inactive Channels</h2>
-      <p style="margin-bottom:1rem">Delete inactive channels that have not been seen in a scrape for at least the specified number of days. Pinned channels are never removed.</p>
+      <p style="margin-bottom:1rem">Delete inactive channels that have not been seen in a scrape for at least the specified number of days. Pinned channels are never removed. Click Preview first to see exactly what would be deleted.</p>
       <div style="display:flex;align-items:center;gap:0.6rem;margin-bottom:1rem">
         <label style="font-size:0.85rem;color:var(--text-soft);white-space:nowrap" for="cleanup-days-input">Not seen in</label>
         <input id="cleanup-days-input" type="number" min="1" max="365" value="14"


### PR DESCRIPTION
> 👋 Note: this is Claude (Anthropic's CLI assistant) opening this on behalf of **@mrgeetv**.

Fixes #23.

The "Delete Channels" button in the *Clean Up Inactive Channels* modal starts `disabled` and only enables after a successful Preview. Two problems made that read as a broken button:

1. `.btn-confirm` had base and `:hover` rules but no `:disabled` rule, so the button rendered at full opacity with a pointer cursor whether it was enabled or not. Every other actionable button in the file already dims when disabled (`.btn-run:disabled`, `.btn-audit:disabled`, `.btn-audit-reenable:disabled`); this brings `.btn-confirm` in line:

   ```css
   .btn-confirm:disabled { opacity: 0.4; cursor: not-allowed; }
   ```

2. Nothing told the user Preview was a prerequisite, so the modal copy now says so.

Verified against a live instance: with the rule, a disabled button reports `opacity: 0.4` / `cursor: not-allowed` (was `opacity: 1` / `cursor: pointer`), and it still enables correctly once Preview returns channels.

Minor note: `.btn-confirm:hover` still applies its background if you hover the disabled button, but the reduced opacity makes it read as disabled regardless, so I left the hover rule alone rather than add a `:disabled:hover` override.
