### PR TITLE
xumo: follow JSON playlist indirection when resolving a channel

### DIFF
--- a/app/scrapers/xumo.py
+++ b/app/scrapers/xumo.py
@@ -364,7 +364,7 @@ class XumoScraper(BaseScraper):
         if not source_url:
             return raw_url
 
-        return self._process_stream_uri(source_url)
+        return self._unwrap_playlist_indirection(self._process_stream_uri(source_url))
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -495,6 +495,62 @@ class XumoScraper(BaseScraper):
         query_pairs = [(k, v) for k, v in parse_qsl(parsed.query, keep_blank_values=False) if v != ""]
         cleaned_query = urlencode(query_pairs, doseq=True)
         return urlunparse(parsed._replace(query=cleaned_query))
+
+    # Suffixes that mark a URL as already being a playable manifest.
+    _MANIFEST_SUFFIXES = (".m3u8", ".mpd")
+
+    def _unwrap_playlist_indirection(self, url: str) -> str:
+        """Follow one hop when a channel resolves to a JSON pointer, not a manifest.
+
+        A few Xumo channels are delivered through a provider API that returns
+        the real playlist URL as a bare JSON string instead of serving the
+        manifest itself — Local Now via ottcms.weathergroup.com is the one in
+        the current lineup:
+
+            GET /api/v1/scte35stream/XumoV3  ->  200 application/json
+            "https://…mediatailor….amazonaws.com/…/playlist.m3u8?…"
+
+        Lenient players (VLC) sniff that and follow it; strict ones do not.
+        Shaka requires a leading #EXTM3U and reports the JSON body as
+        HLS_PLAYLIST_HEADER_MISSING (error 4015), so the channel is unplayable
+        in the browser and through the PrismCast bridge.
+
+        Only probed when the resolved URL has no manifest suffix — true for
+        exactly one of 72 channels here — so the common path costs no extra
+        request. Deliberately narrow: a non-JSON content type, a non-string
+        payload, or anything that is not an https URL is left untouched, so a
+        provider returning JSON for some other reason cannot break playback.
+        """
+        if urlparse(url).path.lower().endswith(self._MANIFEST_SUFFIXES):
+            return url
+
+        try:
+            response = self.session.get(url, timeout=self.REQUEST_TIMEOUT_SECONDS)
+            response.raise_for_status()
+        except Exception as exc:  # noqa: BLE001 - never let a probe break playback
+            logger.debug("[xumo] indirection probe failed for %s: %s", url[:80], exc)
+            return url
+
+        content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
+        if "json" not in content_type:
+            return url
+
+        try:
+            payload = response.json()
+        except ValueError:
+            return url
+
+        if not isinstance(payload, str):
+            return url
+        candidate = payload.strip()
+        if not candidate.startswith("https://"):
+            return url
+
+        logger.info(
+            "[xumo] unwrapped playlist indirection: %s -> %s",
+            urlparse(url).netloc, urlparse(candidate).netloc,
+        )
+        return candidate
 
     @staticmethod
     def _parse_xumo_dt(value: Any) -> datetime | None:


### PR DESCRIPTION
## Symptom

Local Now on Xumo (`/play/xumo/99991282.m3u8`) is unplayable in Shaka Player,
which reports **error 4015 `MANIFEST.HLS_PLAYLIST_HEADER_MISSING`**. It plays
fine in VLC, which is what makes it easy to miss.

That means the watch page and the PrismCast bridge cannot play the channel,
since both go through Shaka.

## What is actually happening

```console
$ curl -sD- http://127.0.0.1:5523/play/xumo/99991282.m3u8 | head -8
HTTP/1.1 302 FOUND
Location: https://ottcms.weathergroup.com/api/v1/scte35stream/XumoV3?reqArgs.zipcode=30101&…

$ curl -sD- "https://ottcms.weathergroup.com/api/v1/scte35stream/XumoV3?…" | tail -2
content-type: application/json; charset=utf-8

"https://01b8e416…mediatailor.us-east-1.amazonaws.com:443/v1/master/…/DIST_LocalNow_Xumo/playlist.m3u8?…"
```

`ottcms.weathergroup.com/api/v1/scte35stream/XumoV3` is not a manifest. It is a
provider indirection endpoint that returns the real playlist URL as a bare JSON
string. `resolve()` returns it as though it were the stream.

The stream itself is fine — fetching the wrapped URL gives a valid master:

```console
$ curl -s "https://01b8e416…/playlist.m3u8?…" | head -3
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-STREAM-INF:CODECS="avc1.64001f,mp4a.40.2",RESOLUTION=1280x720,FRAME-RATE=29.97,BANDWIDTH=2630000
```

## Why players disagree

Shaka mandates a leading `#EXTM3U` and rejects anything else outright, which is
exactly what 4015 means. VLC sniffs the body, spots a bare URL and follows it.
Same upstream response, different tolerance — so the bug is invisible in a
desktop player and fatal in the browser.

## The fix

`resolve()` now passes its result through `_unwrap_playlist_indirection()`,
which follows one hop when the resolved URL is a JSON pointer rather than a
manifest. Three guards keep the blast radius at zero:

- **Only probed when the URL has no `.m3u8`/`.mpd` suffix.** That was true for
  1 of 72 Xumo channels in the lineup this was found on, so the other 71 take
  no extra request at all.
- **Requires a JSON content type, a string payload, and an `https://` URL.**
  Anything else is passed through untouched, so a provider returning JSON for
  some other reason cannot break playback.
- **Probe failures are swallowed** and fall back to the original URL, so a slow
  or flaky provider API cannot turn a working channel into a broken one.

## Reproducing

Before:

```console
$ curl -sL http://127.0.0.1:5523/play/xumo/99991282.m3u8 | head -1
"https://01b8e416…playlist.m3u8?…"      # JSON string -> Shaka 4015
```

After:

```console
$ curl -sL http://127.0.0.1:5523/play/xumo/99991282.m3u8 | head -1
#EXTM3U
```

Verified on a running instance: the channel resolves to a real manifest and
logs `[xumo] unwrapped playlist indirection: ottcms.weathergroup.com -> …`;
five other Xumo channels resolve unchanged, with the unwrap probe count staying
flat, confirming they take no extra hop.
