### PR TITLE
Don't require fc_player_bridge_encoder_url for ah4c-only FastChannels Player setups

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell scripts must keep LF endings regardless of a checkout's core.autocrlf —
+# a CRLF shebang makes the kernel look for an interpreter named "/bin/bash\r"
+# and the container fails with "exec /app/entrypoint.sh: no such file or directory".
+*.sh text eol=lf
+entrypoint.sh text eol=lf

--- a/app/routes/play.py
+++ b/app/routes/play.py
@@ -4852,9 +4852,11 @@ def play_fc_player_bridge(source_name: str, channel_id: str):
 
     settings = AppSettings.get()
     encoder_url = settings.effective_fc_player_bridge_encoder_url()
-    if not encoder_url:
+    ah4c_url = settings.effective_fc_player_bridge_ah4c_url()
+    if not encoder_url and not ah4c_url:
         logger.error(
-            '[fc-player] play request for %s/%s but fc_player_bridge_encoder_url is not configured',
+            '[fc-player] play request for %s/%s but neither fc_player_bridge_encoder_url '
+            'nor ah4c support is configured',
             source_name, channel_id,
         )
         return Response('FastChannels Player encoder URL is not configured.\n', status=503, mimetype='text/plain')
@@ -4881,10 +4883,17 @@ def play_fc_player_bridge(source_name: str, channel_id: str):
         channel_key=f'{source_name}:{channel_id}',
     )
     logger.info(
-        '[fc-player] request_id=%s ip=%s source=%s channel_id=%s channel_name=%s triggered=%s -> encoder',
+        '[fc-player] request_id=%s ip=%s source=%s channel_id=%s channel_name=%s triggered=%s -> %s',
         getattr(g, 'request_id', '-'), _client_ip(), source_name, channel_id, channel.name, triggered,
+        'encoder' if encoder_url else 'ah4c (trigger-only)',
     )
-    return redirect(encoder_url, 302)
+    if encoder_url:
+        return redirect(encoder_url, 302)
+    # ah4c-only setup: ah4c is already relaying its own HDMI capture and calls this
+    # route (via the exported bmitune.sh) purely to fire the adb play trigger, then
+    # confirms playback itself with `adb shell dumpsys media_session`. There's no
+    # encoder URL to redirect to, so just acknowledge the trigger.
+    return Response('', status=204)
 
 
 @play_bp.route('/play/fc-player/<source_name>/<channel_id>.m3u')


### PR DESCRIPTION
The /play/fc-player/<source>/<channel_id>.m3u8 route (play_fc_player_bridge) returned 503 whenever fc_player_bridge_encoder_url was unset — but in an ah4c setup that field is intentionally left blank (the setup doc says to skip it). ah4c relays its own HDMI capture and calls this route only to fire the adb play trigger, discarding the response before confirming playback via adb shell dumpsys media_session.

Result: ah4c users hit [fc-player] ... but fc_player_bridge_encoder_url is not configured and channels wouldn't tune. The admin Feeds/Settings pages already treated ah4c as an independent capture path; only this runtime route hadn't caught up.

Changes in app/routes/play.py:

503 only when neither an encoder URL nor ah4c support (effective_fc_player_bridge_ah4c_url()) is configured. Single-encoder path unchanged: still 302s to the encoder URL when set. ah4c-only path: after triggering, return 204 No Content instead of erroring — enough for bmitune.sh to proceed to its playback check.