### PR TITLE
Support multiple ah4c tuners in the FastChannels Player bridge

### DIFF
--- a/app/data/ah4c_scripts/bmitune.sh
+++ b/app/data/ah4c_scripts/bmitune.sh
@@ -46,8 +46,16 @@ is_media_playing() {
 }
 
 trigger() {
-	echo "[TRIGGER] $FASTCHANNELS_URL/play/fc-player/$SOURCE/$CHANNEL_ID.m3u8"
-	curl -s -o /dev/null --max-time 10 "$FASTCHANNELS_URL/play/fc-player/$SOURCE/$CHANNEL_ID.m3u8"
+	# Forward the tuner adb address ah4c allocated for this tune. FastChannels does
+	# the `am start` server-side, so without this it would always trigger its single
+	# configured device — wrong once ah4c is fronting more than one streaming stick.
+	# Absent/empty $TUNERIP: server falls back to its configured adb address.
+	local url="$FASTCHANNELS_URL/play/fc-player/$SOURCE/$CHANNEL_ID.m3u8"
+	if [ -n "$TUNERIP" ]; then
+		url="$url?adb=$TUNERIP"
+	fi
+	echo "[TRIGGER] $url"
+	curl -s -o /dev/null --max-time 10 "$url"
 }
 
 trigger

--- a/app/fc_player_bridge.py
+++ b/app/fc_player_bridge.py
@@ -385,7 +385,7 @@ def check_idle_and_stop() -> None:
 
 
 def trigger_channel(manifest_url: str, license_url: str | None = None, *, name: str = 'FastChannels',
-                     channel_key: str | None = None) -> bool:
+                     channel_key: str | None = None, adb_address: str | None = None) -> bool:
     """Tell the FastChannels Player app to start playing this stream right now.
 
     manifest_url should already be the fully-resolved play URL (same shape
@@ -396,11 +396,16 @@ def trigger_channel(manifest_url: str, license_url: str | None = None, *, name: 
 
     channel_key (f'{source_name}:{channel_id}') is only used when the idle-stop
     watchdog is enabled — see note_trigger().
+
+    adb_address overrides the single configured device for this one trigger — ah4c
+    supplies it (per allocated tuner) when it's fronting more than one streaming stick.
+    When set, idle-stop tracking is skipped: it's single-device global state, and the
+    ah4c stop script already force-stops each stick on its own disconnect.
     """
-    address = _adb_address()
+    address = adb_address or _adb_address()
     drm = bool(license_url)
 
-    if channel_key and idle_stop_enabled():
+    if channel_key and adb_address is None and idle_stop_enabled():
         note_trigger(channel_key)
 
     try:

--- a/app/routes/play.py
+++ b/app/routes/play.py
@@ -921,6 +921,28 @@ def _client_ip() -> str:
     return request.remote_addr or 'unknown'
 
 
+_ADB_ADDRESS_RE = re.compile(r'^[A-Za-z0-9.\-]{1,255}(?::\d{1,5})?$')
+
+
+def _fc_player_adb_override(raw: str | None) -> str | None:
+    """Per-request adb target supplied by ah4c's bmitune.sh as ?adb=<tunerip>.
+
+    When one FastChannels install fronts multiple ah4c tuners, each wired to its own
+    streaming stick, ah4c is the tuner manager: it allocates a tuner per tune and
+    passes that stick's adb address into bmitune.sh. FastChannels does the `am start`
+    server-side, so it has to be told which stick to hit. We trust the well-formed
+    host[:port] ah4c hands us (it's already trusted on the LAN); anything malformed or
+    absent falls back to the single configured fc_player_bridge_adb_address.
+    """
+    raw = (raw or '').strip()
+    if not raw:
+        return None
+    if not _ADB_ADDRESS_RE.match(raw):
+        logger.warning('[fc-player] ignoring malformed ?adb= override: %r', raw)
+        return None
+    return raw
+
+
 def _stream_info_summary(si: dict | None) -> tuple:
     """Comparable tuple of the badge-relevant fields of a stream_info dict.
     Used to skip a DB write when only volatile fields (per-session variant
@@ -4878,13 +4900,16 @@ def play_fc_player_bridge(source_name: str, channel_id: str):
         logger.error('[fc-player] no manifest URL resolved for %s/%s', source_name, channel_id)
         return _unavailable_response()
 
+    adb_override = _fc_player_adb_override(request.args.get('adb'))
     triggered = fc_player_bridge.trigger_channel(
         manifest_url, license_url, name=channel.name or 'FastChannels',
         channel_key=f'{source_name}:{channel_id}',
+        adb_address=adb_override,
     )
     logger.info(
-        '[fc-player] request_id=%s ip=%s source=%s channel_id=%s channel_name=%s triggered=%s -> %s',
-        getattr(g, 'request_id', '-'), _client_ip(), source_name, channel_id, channel.name, triggered,
+        '[fc-player] request_id=%s ip=%s source=%s channel_id=%s channel_name=%s adb=%s triggered=%s -> %s',
+        getattr(g, 'request_id', '-'), _client_ip(), source_name, channel_id, channel.name,
+        adb_override or 'default', triggered,
         'encoder' if encoder_url else 'ah4c (trigger-only)',
     )
     if encoder_url:
@@ -4918,6 +4943,9 @@ def play_fc_player_bridge_vlc(source_name: str, channel_id: str):
         abort(404)
     base_url = request.host_url.rstrip('/')
     stream_url = f'{base_url}/play/fc-player/{source_name}/{channel_id}.m3u8'
+    adb_override = _fc_player_adb_override(request.args.get('adb'))
+    if adb_override:
+        stream_url += f'?adb={adb_override}'
     playlist = f'#EXTM3U\n#EXTINF:-1,{channel.name}\n{stream_url}\n'
     return Response(
         playlist,

--- a/docs/fc-player-setup.md
+++ b/docs/fc-player-setup.md
@@ -145,8 +145,11 @@ In the shared section at the top, complete:
 - **Enable FastChannels Player:** Turns the feature on — required before
   either capture method works.
 - **Firestick / Android TV IP address:** Enter the IP address found in step 2.
-  FastChannels adds ADB port `5555` automatically. Shared by both capture
-  methods, since both trigger the same device over ADB.
+  FastChannels adds ADB port `5555` automatically. This is the device the
+  single-encoder method always triggers. The ah4c method triggers whichever
+  device ah4c allocated for each tune (see [ah4c support](#ah4c-support)),
+  falling back to this one only when ah4c doesn't name a device — so with more
+  than one ah4c tuner, set this to any one of the sticks.
 - **Stop playback when nobody's watching:** Optional. When enabled, playback
   stops after about five minutes without a confirmed viewer.
 - **Show captions when available:** Optional. Renders an English subtitle/CC
@@ -229,7 +232,10 @@ build or maintain on the ah4c side.
    dedicated one) per tuner, and either `ENCODERn_URL` or `CMDn`/`CMDn_DEVICE`
    for your capture hardware. `IPADDRESS` should be set to wherever ah4c
    itself is reachable from — the same address you'll enter in FastChannels
-   below.
+   below. Multiple tuners each with their own `TUNERn_IP` and encoder are
+   supported: ah4c allocates a tuner per tune and the exported `bmitune.sh`
+   passes that tuner's device to FastChannels, so concurrent tunes each trigger
+   their own streaming stick.
 2. In FastChannels, go to **Settings → FastChannels Player → ah4c** and:
    - Toggle **Enable ah4c support** on.
    - Enter ah4c's **server URL** (e.g. `http://192.168.1.30:7654`) — the same


### PR DESCRIPTION
Problem: The fc-player bridge did the adb am start server-side against a single global fc_player_bridge_adb_address. With more than one ah4c tuner (each wired to its own streaming stick), a second concurrent tune triggered the same stick as the first — stealing its channel — while the second tuner's encoder kept capturing a device that was never tuned.

Fix: Let ah4c, which already allocates a tuner per tune, tell FastChannels which stick to hit.

bmitune.sh trigger() now appends ?adb=$TUNERIP (the address ah4c passes it); omitted when empty. play_fc_player_bridge reads ?adb=, validates it as host[:port], and passes it to trigger_channel(). Log line gains adb=<addr|default>. The .m3u sibling forwards the arg through. trigger_channel(..., adb_address=None) uses the override when present, else the configured address. Idle-stop tracking is skipped for overridden triggers (it's single-device global state, and stopbmitune.sh already stops each stick per-disconnect). Docs updated: multi-tuner ah4c is supported; the global device IP is the fallback used only when ah4c doesn't name one. Compatibility: No ?adb= (direct /watch, single-encoder path, not-yet-re-exported scripts) behaves exactly as before. Existing ah4c users must re-export their scripts to get the updated bmitune.sh, and authorize FastChannels' adb key on each additional stick.