### PR TITLE
Add Bridge post-install healthcheck

### DIFF
--- a/app/fc_player_bridge.py
+++ b/app/fc_player_bridge.py
@@ -714,7 +714,7 @@ def _recent_web_heartbeat(channel_key: str) -> bool:
         return False
 
 
-def _stop_playback() -> bool:
+def stop_playback() -> bool:
     """Force-stops the player app entirely — blunt, but already proven reliable this
     session for clearing stale DRM sessions. No JSON-RPC-style control channel exists
     to ask it to stop gracefully (unlike the old Kodi bridge's Player.Stop)."""
@@ -731,6 +731,11 @@ def _stop_playback() -> bool:
         logger.warning('[fc-player] idle-stop: force-stop failed: %s', e)
         return False
     return result.returncode == 0
+
+
+def _stop_playback() -> bool:
+    """Compatibility name for the idle-stop watchdog's internal call sites."""
+    return stop_playback()
 
 
 def check_idle_and_stop() -> None:

--- a/app/routes/api_settings.py
+++ b/app/routes/api_settings.py
@@ -87,6 +87,55 @@ def _looks_like_mpeg_ts(payload: bytes) -> bool:
                for offset in range(upper_bound))
 
 
+def _mpeg_ts_stream_summary(payload: bytes) -> str:
+    """Best-effort codec summary from PAT/PMT packets in a short TS sample."""
+    packet_start = next((offset for offset in range(min(188, len(payload)))
+                         if offset + 376 < len(payload)
+                         and payload[offset] == payload[offset + 188] == payload[offset + 376] == 0x47), None)
+    if packet_start is None:
+        return 'MPEG-TS packets detected; program map was not available in this sample.'
+    pmt_pids: set[int] = set()
+    stream_types: set[int] = set()
+    for offset in range(packet_start, len(payload) - 187, 188):
+        packet = payload[offset:offset + 188]
+        if packet[0] != 0x47:
+            continue
+        pid = ((packet[1] & 0x1f) << 8) | packet[2]
+        has_payload = ((packet[3] >> 4) & 0x03) in {1, 3}
+        if not has_payload or not (packet[1] & 0x40):
+            continue
+        payload_offset = 4
+        if ((packet[3] >> 4) & 0x03) == 3:
+            payload_offset += 1 + packet[4]
+        if payload_offset >= len(packet):
+            continue
+        section = packet[payload_offset + 1 + packet[payload_offset]:]
+        if len(section) < 12:
+            continue
+        if pid == 0 and section[0] == 0x00:  # PAT
+            section_end = min(len(section), 3 + (((section[1] & 0x0f) << 8) | section[2]))
+            for index in range(8, section_end - 3, 4):
+                program = (section[index] << 8) | section[index + 1]
+                if program:
+                    pmt_pids.add(((section[index + 2] & 0x1f) << 8) | section[index + 3])
+        elif pid in pmt_pids and section[0] == 0x02:  # PMT
+            section_end = min(len(section), 3 + (((section[1] & 0x0f) << 8) | section[2]))
+            program_info_length = ((section[10] & 0x0f) << 8) | section[11]
+            index = 12 + program_info_length
+            while index + 4 < section_end - 4:
+                stream_types.add(section[index])
+                es_info_length = ((section[index + 3] & 0x0f) << 8) | section[index + 4]
+                index += 5 + es_info_length
+    names = {
+        0x02: 'MPEG-2 video', 0x1B: 'H.264 video', 0x24: 'H.265/HEVC video',
+        0x0F: 'AAC audio', 0x11: 'AAC-LATM audio', 0x03: 'MPEG audio',
+        0x04: 'MPEG audio', 0x81: 'AC-3 audio', 0x87: 'E-AC-3 audio',
+    }
+    identified = [names.get(stream_type, f'stream type 0x{stream_type:02x}')
+                  for stream_type in sorted(stream_types)]
+    return 'Detected: ' + ', '.join(identified) if identified else 'MPEG-TS packets detected; program map was not available in this sample.'
+
+
 def _m3u_attr(line: str, name: str) -> str:
     """Return one quoted attribute from an EXTINF line, without trusting it as HTML."""
     match = re.search(rf'\b{re.escape(name)}="([^"]*)"', line, flags=re.IGNORECASE)
@@ -398,7 +447,7 @@ def bridge_live_test():
     try:
         with _req.get(encoder_url, stream=True, timeout=(3, 8)) as response:
             response.raise_for_status()
-            sample = next(response.iter_content(chunk_size=32 * 1024), b'')
+            sample = next(response.iter_content(chunk_size=64 * 1024), b'')
             elapsed_ms = int((time.monotonic() - started) * 1000)
     except _req.RequestException:
         return jsonify({
@@ -429,11 +478,22 @@ def bridge_live_test():
         'bytes_received': len(sample),
         'elapsed_ms': elapsed_ms,
         'content_type': (response.headers.get('Content-Type') or 'unspecified').split(';', 1)[0],
+        'media_summary': _mpeg_ts_stream_summary(sample) if payload_ok else 'No recognizable MPEG-TS program data.',
         'player_playing': player_playing,
         'player_visible': player_visible,
         'player_focus': device.get('focus') if device.get('ok') else None,
         'detail': detail,
     })
+
+
+@settings_bp.route('/settings/bridge/live-test/stop', methods=['POST'])
+def bridge_live_test_stop():
+    """Stop the Player after an explicit live test (or any fixed HDMI test tune)."""
+    if not AppSettings.get().effective_fc_player_bridge_adb_address():
+        return jsonify({'error': 'No HDMI Capture device IP is configured.'}), 409
+    if not fc_player_bridge.stop_playback():
+        return jsonify({'error': 'FastChannels could not stop the Player device over ADB.'}), 502
+    return jsonify({'ok': True, 'message': 'FastChannels Player was stopped on the HDMI Capture device.'})
 
 
 @settings_bp.route('/settings/bridge/healthcheck', methods=['POST'])
@@ -510,7 +570,8 @@ def bridge_healthcheck():
                             add('fail', 'HDMI Capture payload', f'The capture endpoint returned HTTP {response.status_code} but sent no data within {elapsed_ms} ms.',
                                 'Check the Channels DVR capture device and confirm it is producing a live stream.')
                         elif _looks_like_mpeg_ts(sample):
-                            add('ok', 'HDMI Capture payload', f'Received {len(sample):,} bytes of MPEG-TS capture data in {elapsed_ms} ms ({content_type}).')
+                            add('ok', 'HDMI Capture payload',
+                                f'Received {len(sample):,} bytes of MPEG-TS capture data in {elapsed_ms} ms ({content_type}). {_mpeg_ts_stream_summary(sample)}')
                         else:
                             add('warn', 'HDMI Capture payload', f'Received {len(sample):,} bytes in {elapsed_ms} ms, but the sample did not resemble MPEG-TS ({content_type}).',
                                 'Open the exact capture stream URL in VLC and verify Channels DVR is serving the expected capture stream.')

--- a/app/routes/api_settings.py
+++ b/app/routes/api_settings.py
@@ -9,7 +9,7 @@ from urllib.parse import urlsplit
 
 from flask import Blueprint, jsonify, request, current_app, Response
 from ..extensions import db
-from ..models import AppSettings
+from ..models import AppSettings, Source, Channel
 from .. import fc_player_bridge
 from ..timezone_utils import normalize_timezone_name, write_timezone_cache
 
@@ -215,6 +215,124 @@ def test_fc_player():
             'warning': True,
             'message': f'{message} Encoder/capture stream URL is not reachable — bridged channels will fail until that stream is up.',
         })
+
+
+@settings_bp.route('/settings/bridge/healthcheck', methods=['POST'])
+def bridge_healthcheck():
+    """Non-disruptive, forum-shareable health check for hardware bridge setup.
+
+    This intentionally does not tune a channel or change a device. PrismCast has
+    its own deeper capture diagnostic, so this check only links users to it.
+    """
+    from ..scrapers.registry import drm_capable_source_names
+
+    settings = AppSettings.get()
+    checks: list[dict] = []
+
+    def add(status: str, name: str, detail: str, fix: str = '') -> None:
+        checks.append({'status': status, 'name': name, 'detail': detail, 'fix': fix})
+
+    if settings.bridge_enabled:
+        add('ok', 'Bridge mode', 'Enabled. Eligible DRM channels can use a configured capture path.')
+    else:
+        add('warn', 'Bridge mode', 'Disabled. DRM channels will follow the normal disabled-DRM behavior.',
+            'Enable Bridge mode when your capture path is ready.')
+
+    capable_names = set(drm_capable_source_names())
+    enabled_source_ids = [source.id for source in Source.query.filter(
+        Source.name.in_(capable_names), Source.is_enabled.is_(True), Source.epg_only.is_not(True)
+    ).all()] if capable_names else []
+    bridge_candidates = (Channel.query.filter(Channel.source_id.in_(enabled_source_ids),
+                                               Channel.is_active.is_(True),
+                                               Channel.is_enabled.is_(True),
+                                               Channel.requires_drm_bridge.is_(True)).count()
+                         if enabled_source_ids else 0)
+    if not enabled_source_ids:
+        add('skip', 'Bridge sources', 'No DRM-capable sources are enabled.')
+    elif bridge_candidates:
+        add('ok', 'Bridge sources', f'{len(enabled_source_ids)} enabled source(s); {bridge_candidates} channel(s) are marked for bridge output.')
+    else:
+        add('warn', 'Bridge sources', f'{len(enabled_source_ids)} DRM-capable source(s) are enabled, but none are marked for bridge output.',
+            'Run Stream Audit on the sources you intend to bridge.')
+
+    # HDMI Capture is a fixed single-stream path. Probe only when it has been
+    # selected/configured, so unused hardware never creates a scary failure.
+    if not settings.fc_player_bridge_enabled:
+        add('skip', 'HDMI Capture', 'Hardware capture is disabled.')
+    elif not settings.effective_fc_player_bridge_adb_address():
+        add('warn', 'HDMI Capture device', 'No Android TV / Fire TV device IP is configured.',
+            'Enter the device IP in HDMI Capture, then approve its ADB prompt on the TV.')
+    else:
+        ok, message = fc_player_bridge.test_connection()
+        add('ok' if ok else 'fail', 'FastChannels Player device', message,
+            '' if ok else 'Enable ADB or Network Debugging, retry, and approve “Allow USB debugging?” on the TV.')
+
+        encoder_url = settings.effective_fc_player_bridge_encoder_url()
+        if not encoder_url:
+            add('skip', 'HDMI Capture stream', 'No fixed encoder stream is configured.')
+        else:
+            try:
+                with _req.get(encoder_url, stream=True, timeout=3) as response:
+                    if response.ok:
+                        add('ok', 'HDMI Capture stream', 'The fixed encoder stream responded successfully.')
+                    else:
+                        add('warn', 'HDMI Capture stream', f'The fixed encoder stream returned HTTP {response.status_code}.',
+                            'Confirm the capture device is powered on and the saved stream URL is correct.')
+            except _req.RequestException:
+                add('fail', 'HDMI Capture stream', 'The fixed encoder stream could not be reached.',
+                    'Confirm the capture device is powered on and reachable from FastChannels.')
+
+    # ah4c owns its own capture hardware. Its status endpoint plus the per-tuner
+    # ADB checks provide a useful setup check without starting a tune.
+    if not settings.fc_player_bridge_ah4c_enabled:
+        add('skip', 'ah4c Capture', 'ah4c Capture is disabled.')
+    elif not settings.effective_fc_player_bridge_ah4c_url():
+        add('warn', 'ah4c Capture', 'ah4c Capture is enabled but its server URL is blank.',
+            'Enter the ah4c server URL and save it.')
+    else:
+        try:
+            tuners = fc_player_bridge.verify_ah4c_tuners()
+            if not tuners:
+                add('warn', 'ah4c tuners', 'ah4c is reachable but reports no configured TUNERn_IP values.',
+                    'Configure at least one tuner and TUNERn_IP in ah4c.')
+            else:
+                authorized = sum(1 for tuner in tuners if tuner.get('authorized'))
+                status = 'ok' if authorized == len(tuners) else 'fail'
+                add(status, 'ah4c tuners', f'{authorized}/{len(tuners)} tuner device(s) are authorized by FastChannels.',
+                    '' if status == 'ok' else 'Retry an action and approve FastChannels’ ADB authorization prompt on each affected TV.')
+        except fc_player_bridge.FcPlayerNotConfigured:
+            add('warn', 'ah4c tuners', 'ah4c is not fully configured.', 'Save the ah4c server URL and retry.')
+        except (ValueError, _req.RequestException):
+            add('fail', 'ah4c server', 'FastChannels could not read ah4c status.',
+                'Confirm the ah4c URL, network reachability, and its /api/status endpoint.')
+
+    if settings.prismcast_enabled:
+        if settings.effective_prismcast_url():
+            add('info', 'PrismCast Capture', 'Configured. Use PrismCast’s dedicated Test setup button for its browser and live-capture diagnostic.')
+        else:
+            add('warn', 'PrismCast Capture', 'Enabled but no PrismCast server URL is configured.',
+                'Enter the PrismCast server URL or turn this method off.')
+    else:
+        add('skip', 'PrismCast Capture', 'Disabled. Its dedicated diagnostic was not run.')
+
+    failed = sum(check['status'] == 'fail' for check in checks)
+    warned = sum(check['status'] == 'warn' for check in checks)
+    overall = 'fail' if failed else ('warn' if warned else 'ok')
+    label = {'ok': 'READY', 'warn': 'NEEDS ATTENTION', 'fail': 'NOT READY'}[overall]
+    report = ['FastChannels Bridge Healthcheck', f'Overall: {label}', '']
+    for check in checks:
+        marker = {'ok': 'PASS', 'warn': 'WARN', 'fail': 'FAIL', 'skip': 'SKIP', 'info': 'INFO'}[check['status']]
+        report.append(f'[{marker}] {check["name"]}: {check["detail"]}')
+        if check['fix']:
+            report.append(f'  Next step: {check["fix"]}')
+    return jsonify({
+        'overall': overall,
+        'overall_label': label,
+        'checks': checks,
+        'summary': {'ok': sum(check['status'] == 'ok' for check in checks), 'warn': warned,
+                    'fail': failed, 'skip': sum(check['status'] == 'skip' for check in checks)},
+        'forum_report': '\n'.join(report),
+    })
 
 
 @settings_bp.route('/settings/fc-player/install', methods=['POST'])

--- a/app/routes/api_settings.py
+++ b/app/routes/api_settings.py
@@ -47,6 +47,24 @@ def _normalize_server_url(value: str | None, default_port: int | None = None) ->
     return f'{scheme}://{host}'.rstrip('/')
 
 
+def _normalize_stream_url(value: str | None) -> str | None:
+    """Normalize an HTTP stream URL while retaining its required query string.
+
+    The ordinary server-address normalizer intentionally discards a path/query.
+    A Channels DVR ``stream.mpg`` link can carry ``format=ts`` and, on some
+    installations, a session token, so those are part of this setting's identity.
+    """
+    raw = (value or '').strip()
+    if not raw:
+        return None
+    if '://' not in raw:
+        raw = f'http://{raw}'
+    parsed = urlsplit(raw)
+    if parsed.scheme not in {'http', 'https'} or not parsed.netloc:
+        return None
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path or '/', parsed.query, ''))
+
+
 def _bridge_host_from_input(value: str | None) -> str | None:
     """Extract a bare host from a device-bridge IP field — strips any scheme/port
     the user typed. The admin form takes one "IP[:port]" field and derives the
@@ -193,7 +211,10 @@ def app_settings():
                 return jsonify({'error': 'Invalid Firestick/Android TV IP address.'}), 422
             row.fc_player_bridge_adb_address = f'{_fcp_host}:5555' if _fcp_host else None
         if 'fc_player_encoder_url' in data:
-            row.fc_player_bridge_encoder_url = _normalize_server_url(data['fc_player_encoder_url'], default_port=None)
+            encoder_url = _normalize_stream_url(data['fc_player_encoder_url'])
+            if data.get('fc_player_encoder_url') and not encoder_url:
+                return jsonify({'error': 'Invalid HDMI capture stream URL.'}), 422
+            row.fc_player_bridge_encoder_url = encoder_url
         if 'fc_player_idle_stop_enabled' in data:
             row.fc_player_bridge_idle_stop_enabled = bool(data['fc_player_idle_stop_enabled'])
         if 'fc_player_captions_enabled' in data:

--- a/app/routes/api_settings.py
+++ b/app/routes/api_settings.py
@@ -145,6 +145,20 @@ def _channels_dvr_capture_streams(dvr_url: str) -> list[dict]:
     return choices
 
 
+def _stream_debug_path(stream_url: str) -> str:
+    """Useful stream identity for diagnostics without exposing host or credentials."""
+    parsed = urlsplit(stream_url)
+    redacted_keys = {'session', 'token', 'access_token', 'auth', 'authorization', 'key', 'password'}
+    query_parts = []
+    for part in parsed.query.split('&'):
+        if not part:
+            continue
+        key, separator, value = part.partition('=')
+        query_parts.append(f'{key}=[redacted]' if key.lower() in redacted_keys else part)
+    query = f'?{"&".join(query_parts)}' if query_parts else ''
+    return f'{parsed.path or "/"}{query}'
+
+
 @settings_bp.route('/settings', methods=['GET', 'POST'])
 def app_settings():
     row = AppSettings.get()
@@ -379,6 +393,8 @@ def bridge_healthcheck():
         if not encoder_url:
             add('skip', 'HDMI Capture stream', 'No fixed encoder stream is configured.')
         else:
+            add('info', 'HDMI Capture endpoint',
+                f'Testing saved stream {_stream_debug_path(encoder_url)} from inside the FastChannels container.')
             host = (urlsplit(encoder_url).hostname or '').lower()
             if host in {'localhost', '127.0.0.1', '::1'}:
                 add('warn', 'Docker capture address', 'The capture URL uses localhost, which means the FastChannels container itself—not the Mac or another host.',

--- a/app/routes/api_settings.py
+++ b/app/routes/api_settings.py
@@ -6,7 +6,7 @@ import requests as _req
 
 logger = logging.getLogger(__name__)
 from datetime import datetime, timezone
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urlsplit, urlunsplit, urljoin
 import re
 
 from flask import Blueprint, jsonify, request, current_app, Response
@@ -337,6 +337,103 @@ def fc_player_capture_streams():
     if not streams:
         return jsonify({'error': 'Channels DVR returned no MPEG-TS stream entries. Confirm the capture device is added and enabled in Channels DVR.'}), 404
     return jsonify({'streams': streams})
+
+
+@settings_bp.route('/settings/bridge/live-test-channels', methods=['GET'])
+def bridge_live_test_channels():
+    """Bridge-ready channels that are safe candidates for an explicit live test."""
+    rows = (Channel.query.join(Source)
+            .filter(Channel.is_active.is_(True), Channel.is_enabled.is_(True),
+                    Channel.requires_drm_bridge.is_(True), Source.is_enabled.is_(True))
+            .order_by(Source.display_name, Channel.name)
+            .limit(250).all())
+    return jsonify({'channels': [
+        {'id': channel.id, 'label': f'{channel.source.display_name} · {channel.name or channel.source_channel_id}'}
+        for channel in rows
+    ]})
+
+
+@settings_bp.route('/settings/bridge/live-test', methods=['POST'])
+def bridge_live_test():
+    """Explicit, disruptive Player → HDMI Capture verification for one channel."""
+    settings = AppSettings.get()
+    if not fc_player_bridge.hdmi_bridge_active(settings):
+        return jsonify({'error': 'Enable Bridge mode, HDMI Capture, a device IP, and a fixed capture stream first.'}), 409
+    data = request.get_json(force=True) or {}
+    try:
+        channel_id = int(data.get('channel_id'))
+    except (TypeError, ValueError):
+        return jsonify({'error': 'Choose a bridge-ready channel to test.'}), 422
+    channel = (Channel.query.join(Source)
+               .filter(Channel.id == channel_id, Channel.is_active.is_(True), Channel.is_enabled.is_(True),
+                       Channel.requires_drm_bridge.is_(True), Source.is_enabled.is_(True))
+               .first())
+    if channel is None:
+        return jsonify({'error': 'That channel is no longer eligible for a bridge test. Refresh the list and choose another.'}), 404
+
+    try:
+        from .api_playback import _get_playback_info
+        info = _get_playback_info(channel, fast_mode=False)
+        manifest_url = info.get('preview_url') or info.get('play_url') or ''
+        if manifest_url.startswith('/'):
+            manifest_url = urljoin(request.host_url, manifest_url.lstrip('/'))
+        if not manifest_url:
+            return jsonify({'error': 'FastChannels could not resolve a playable stream for this channel.'}), 502
+        triggered = fc_player_bridge.trigger_channel(
+            manifest_url, info.get('license_url') or None,
+            name=channel.name or 'FastChannels',
+            channel_key=f'{channel.source.name}:{channel.source_channel_id}',
+        )
+    except Exception as exc:
+        logger.warning('[fc-player] live bridge test failed to trigger channel=%s: %s', channel.id, exc)
+        return jsonify({'error': 'FastChannels could not start the selected channel on the Player device.'}), 502
+    if not triggered:
+        return jsonify({'error': 'The Player device did not acknowledge the tune request. Check ADB authorization and Device Controls.'}), 502
+
+    # Give the Player a brief chance to navigate before sampling its fixed HDMI
+    # stream. This endpoint is intentionally opt-in because it changes the TV.
+    time.sleep(4)
+    encoder_url = settings.effective_fc_player_bridge_encoder_url()
+    started = time.monotonic()
+    try:
+        with _req.get(encoder_url, stream=True, timeout=(3, 8)) as response:
+            response.raise_for_status()
+            sample = next(response.iter_content(chunk_size=32 * 1024), b'')
+            elapsed_ms = int((time.monotonic() - started) * 1000)
+    except _req.RequestException:
+        return jsonify({
+            'ok': False, 'channel': channel.name or channel.source_channel_id,
+            'detail': 'The Player accepted the tune request, but FastChannels could not receive the HDMI capture stream afterward.',
+            'endpoint': _stream_debug_path(encoder_url),
+        }), 502
+
+    device = fc_player_bridge.device_controls_status()
+    payload_ok = bool(sample) and _looks_like_mpeg_ts(sample)
+    player_playing = device.get('player_playing') if device.get('ok') else None
+    player_visible = bool(device.get('ok') and 'com.fastchannels.player' in (device.get('focus') or ''))
+    status = 'ok' if payload_ok and (player_playing or player_visible) else ('warn' if payload_ok else 'fail')
+    if payload_ok and player_playing:
+        detail = 'Player tune acknowledged; the Player reports playback active and the capture stream returned MPEG-TS after the tune.'
+    elif payload_ok and player_visible:
+        detail = 'Player tune acknowledged; FastChannels Player is foreground and the capture stream returned MPEG-TS after the tune.'
+    elif payload_ok:
+        detail = ('Player tune acknowledged and the capture stream returned MPEG-TS, but FastChannels could not confirm active Player playback. '
+                  'The stream may be a prior/stale capture; inspect the TV and Player Device Controls.')
+    else:
+        detail = 'Player tune acknowledged, but the capture endpoint returned data that did not resemble MPEG-TS.'
+    return jsonify({
+        'ok': payload_ok,
+        'status': status,
+        'channel': f'{channel.source.display_name} · {channel.name or channel.source_channel_id}',
+        'endpoint': _stream_debug_path(encoder_url),
+        'bytes_received': len(sample),
+        'elapsed_ms': elapsed_ms,
+        'content_type': (response.headers.get('Content-Type') or 'unspecified').split(';', 1)[0],
+        'player_playing': player_playing,
+        'player_visible': player_visible,
+        'player_focus': device.get('focus') if device.get('ok') else None,
+        'detail': detail,
+    })
 
 
 @settings_bp.route('/settings/bridge/healthcheck', methods=['POST'])

--- a/app/routes/api_settings.py
+++ b/app/routes/api_settings.py
@@ -1,6 +1,7 @@
 import logging
 import os as _os
 import json
+import time
 import requests as _req
 
 logger = logging.getLogger(__name__)
@@ -55,6 +56,16 @@ def _bridge_host_from_input(value: str | None) -> str | None:
     if '://' not in raw:
         raw = f'http://{raw}'
     return urlsplit(raw).hostname or None
+
+
+def _looks_like_mpeg_ts(payload: bytes) -> bool:
+    """Recognize a short raw MPEG-TS sample without retaining stream contents."""
+    if len(payload) < 3 * 188:
+        return False
+    upper_bound = len(payload) - (2 * 188)
+    return any(payload[offset] == 0x47 and payload[offset + 188] == 0x47
+               and payload[offset + 376] == 0x47
+               for offset in range(upper_bound))
 
 
 @settings_bp.route('/settings', methods=['GET', 'POST'])
@@ -271,16 +282,31 @@ def bridge_healthcheck():
         if not encoder_url:
             add('skip', 'HDMI Capture stream', 'No fixed encoder stream is configured.')
         else:
+            host = (urlsplit(encoder_url).hostname or '').lower()
+            if host in {'localhost', '127.0.0.1', '::1'}:
+                add('warn', 'Docker capture address', 'The capture URL uses localhost, which means the FastChannels container itself—not the Mac or another host.',
+                    'For Docker Desktop on macOS, use host.docker.internal or the capture host’s LAN IP.')
+            started = time.monotonic()
             try:
-                with _req.get(encoder_url, stream=True, timeout=3) as response:
-                    if response.ok:
-                        add('ok', 'HDMI Capture stream', 'The fixed encoder stream responded successfully.')
-                    else:
+                with _req.get(encoder_url, stream=True, timeout=(3, 4)) as response:
+                    if not response.ok:
                         add('warn', 'HDMI Capture stream', f'The fixed encoder stream returned HTTP {response.status_code}.',
                             'Confirm the capture device is powered on and the saved stream URL is correct.')
+                    else:
+                        sample = next(response.iter_content(chunk_size=32 * 1024), b'')
+                        elapsed_ms = int((time.monotonic() - started) * 1000)
+                        content_type = (response.headers.get('Content-Type') or 'unspecified').split(';', 1)[0]
+                        if not sample:
+                            add('fail', 'HDMI Capture payload', f'The capture endpoint returned HTTP {response.status_code} but sent no data within {elapsed_ms} ms.',
+                                'Check the Channels DVR capture device and confirm it is producing a live stream.')
+                        elif _looks_like_mpeg_ts(sample):
+                            add('ok', 'HDMI Capture payload', f'Received {len(sample):,} bytes of MPEG-TS capture data in {elapsed_ms} ms ({content_type}).')
+                        else:
+                            add('warn', 'HDMI Capture payload', f'Received {len(sample):,} bytes in {elapsed_ms} ms, but the sample did not resemble MPEG-TS ({content_type}).',
+                                'Open the exact capture stream URL in VLC and verify Channels DVR is serving the expected capture stream.')
             except _req.RequestException:
-                add('fail', 'HDMI Capture stream', 'The fixed encoder stream could not be reached.',
-                    'Confirm the capture device is powered on and reachable from FastChannels.')
+                add('fail', 'HDMI Capture payload', 'FastChannels could not connect to the fixed capture stream or receive a payload.',
+                    'Confirm the capture host is reachable from Docker and that Channels DVR is producing the stream.')
 
     # ah4c owns its own capture hardware. Its status endpoint plus the per-tuner
     # ADB checks provide a useful setup check without starting a tune.

--- a/app/routes/api_settings.py
+++ b/app/routes/api_settings.py
@@ -6,7 +6,8 @@ import requests as _req
 
 logger = logging.getLogger(__name__)
 from datetime import datetime, timezone
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
+import re
 
 from flask import Blueprint, jsonify, request, current_app, Response
 from ..extensions import db
@@ -66,6 +67,64 @@ def _looks_like_mpeg_ts(payload: bytes) -> bool:
     return any(payload[offset] == 0x47 and payload[offset + 188] == 0x47
                and payload[offset + 376] == 0x47
                for offset in range(upper_bound))
+
+
+def _m3u_attr(line: str, name: str) -> str:
+    """Return one quoted attribute from an EXTINF line, without trusting it as HTML."""
+    match = re.search(rf'\b{re.escape(name)}="([^"]*)"', line, flags=re.IGNORECASE)
+    return match.group(1).strip() if match else ''
+
+
+def _channels_dvr_capture_streams(dvr_url: str) -> list[dict]:
+    """Read Channels DVR's native MPEG-TS export and return selectable stream URLs.
+
+    Channels deliberately exposes the direct ``stream.mpg`` address only in its M3U
+    export.  Fetching the export here means the user never has to copy its URL or
+    hunt for the non-comment line.  The export can be generated with localhost as
+    its base; rebuild each URL with the configured DVR host, which is the address
+    FastChannels itself can reach from its container.
+    """
+    base = urlsplit(dvr_url)
+    export_url = f'{dvr_url.rstrip("/")}/devices/ANY/channels.m3u?format=ts'
+    response = _req.get(export_url, timeout=(3, 12))
+    response.raise_for_status()
+
+    choices: list[dict] = []
+    seen: set[str] = set()
+    extinf = ''
+    for raw_line in response.text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.upper().startswith('#EXTINF:'):
+            extinf = line
+            continue
+        if line.startswith('#'):
+            continue
+
+        parsed = urlsplit(line)
+        if parsed.scheme not in {'http', 'https'} or not parsed.path.endswith('/stream.mpg'):
+            extinf = ''
+            continue
+        stream_url = urlunsplit((base.scheme, base.netloc, parsed.path, parsed.query, ''))
+        if stream_url in seen:
+            extinf = ''
+            continue
+        seen.add(stream_url)
+        channel_number = _m3u_attr(extinf, 'tvg-chno') or _m3u_attr(extinf, 'channel-number')
+        channel_name = (extinf.rsplit(',', 1)[-1].strip() if ',' in extinf else '')
+        channel_name = _m3u_attr(extinf, 'tvg-name') or channel_name or 'Unnamed channel'
+        label = f'{channel_number} · {channel_name}' if channel_number else channel_name
+        choices.append({'label': label, 'stream_url': stream_url})
+        extinf = ''
+
+    # Capture devices are commonly named Capture, HDMI, or after their encoder.
+    # Keep every usable stream available, but surface likely choices first.
+    choices.sort(key=lambda item: (
+        not any(word in item['label'].lower() for word in ('capture', 'hdmi', 'encoder', 'usb')),
+        item['label'].lower(),
+    ))
+    return choices
 
 
 @settings_bp.route('/settings', methods=['GET', 'POST'])
@@ -226,6 +285,23 @@ def test_fc_player():
             'warning': True,
             'message': f'{message} Encoder/capture stream URL is not reachable — bridged channels will fail until that stream is up.',
         })
+
+
+@settings_bp.route('/settings/fc-player/capture-streams', methods=['GET'])
+def fc_player_capture_streams():
+    """Offer Channels DVR MPEG-TS streams for the fixed HDMI Capture path."""
+    dvr_url = (AppSettings.get().effective_channels_dvr_url() or '').strip().rstrip('/')
+    if not dvr_url:
+        return jsonify({'error': 'Channels DVR URL is not configured. Add it in Settings first.'}), 400
+    try:
+        streams = _channels_dvr_capture_streams(dvr_url)
+    except _req.RequestException as exc:
+        logger.info('[fc-player] could not read Channels DVR M3U export: %s', exc)
+        return jsonify({'error': 'FastChannels could not read the Channels DVR M3U export. Verify the DVR URL in Settings and its network reachability.'}), 502
+
+    if not streams:
+        return jsonify({'error': 'Channels DVR returned no MPEG-TS stream entries. Confirm the capture device is added and enabled in Channels DVR.'}), 404
+    return jsonify({'streams': streams})
 
 
 @settings_bp.route('/settings/bridge/healthcheck', methods=['POST'])

--- a/app/routes/api_settings.py
+++ b/app/routes/api_settings.py
@@ -194,6 +194,92 @@ def _channels_dvr_capture_streams(dvr_url: str) -> list[dict]:
     return choices
 
 
+def _capture_source_value(value, label: str) -> str:
+    """Validate one user-supplied component of a Channels ``capture://`` URL."""
+    value = str(value or '').strip()
+    if not value or '\n' in value or '\r' in value:
+        raise ValueError(f'{label} is required and cannot contain a line break.')
+    return value
+
+
+@settings_bp.route('/settings/fc-player/create-capture-source', methods=['POST'])
+def create_fc_player_capture_source():
+    """Create FastChannels' native USB/HDMI capture source in Channels DVR.
+
+    The source is deliberately a Channels *HLS/Text* source.  Channels turns the
+    local ``capture://`` input into its own export stream; the bridge later uses
+    that export's MPEG-TS ``stream.mpg`` URL.
+    """
+    settings = AppSettings.get()
+    dvr_url = (settings.effective_channels_dvr_url() or '').strip().rstrip('/')
+    if not dvr_url:
+        return jsonify({'error': 'Channels DVR URL is not configured. Add it in Settings first.'}), 400
+
+    data = request.get_json(silent=True) or {}
+    platform = (data.get('platform') or '').strip().lower()
+    if platform not in {'macos', 'windows', 'linux'}:
+        return jsonify({'error': 'Choose macOS, Windows, or Linux.'}), 422
+    try:
+        video = _capture_source_value(data.get('video'), 'Video device')
+        audio = _capture_source_value(data.get('audio'), 'Audio device')
+        framerate = int(data.get('framerate') or 60)
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 422
+    if not 1 <= framerate <= 120:
+        return jsonify({'error': 'Frame rate must be between 1 and 120.'}), 422
+
+    # These are the capture syntaxes documented by Channels.  Linux includes
+    # audio too: e.g. capture://v4l2/video0/hw:1,0/?framerate=60.
+    driver = {'macos': 'avfoundation', 'windows': 'dshow', 'linux': 'v4l2'}[platform]
+    capture_url = f'capture://{driver}/{video}/{audio}/?framerate={framerate}'
+    source_name = 'FastChannels Capture Card'
+    source_id = 'FastChannelsCaptureCard'
+    text = (
+        '#EXTM3U\n'
+        '#EXTINF:-1 channel-id="fastchannels-capture-card",FastChannels Capture Card\n'
+        f'{capture_url}\n'
+    )
+    payload = {
+        'name': source_name,
+        'type': 'HLS',
+        'source': 'Text',
+        'url': '',
+        'text': text,
+        'refresh': '',
+        'limit': '',
+        'satip': '',
+        'numbering': 'ignore',
+        'logos': '',
+        'xmltv_url': '',
+        'xmltv_refresh': '',
+    }
+    try:
+        response = _req.put(f'{dvr_url}/providers/m3u/sources/{source_id}', json=payload,
+                            timeout=20, verify=False)
+        response.raise_for_status()
+    except _req.exceptions.ConnectionError:
+        return jsonify({'error': f'Could not connect to Channels DVR at {dvr_url}.'}), 502
+    except _req.exceptions.Timeout:
+        return jsonify({'error': 'Channels DVR timed out while creating the capture source.'}), 504
+    except _req.exceptions.HTTPError as exc:
+        body = (exc.response.text or '')[:300] if exc.response is not None else ''
+        return jsonify({'error': f'Channels DVR rejected the capture source: {body or exc}'}), 502
+
+    try:
+        streams = _channels_dvr_capture_streams(dvr_url)
+    except _req.RequestException:
+        streams = []
+    stream = next((item for item in streams
+                   if item['label'].lower().endswith('fastchannels capture card')), None)
+    if stream:
+        settings.fc_player_bridge_encoder_url = stream['stream_url']
+        db.session.commit()
+        return jsonify({'ok': True, 'stream_url': stream['stream_url'],
+                        'message': 'Created FastChannels Capture Card and selected its MPEG-TS export stream.'})
+    return jsonify({'ok': True, 'warning': True,
+                    'message': 'Created FastChannels Capture Card. It is still initializing in Channels DVR; use “Find from Channels DVR” in a moment to select its stream.'})
+
+
 def _stream_debug_path(stream_url: str) -> str:
     """Useful stream identity for diagnostics without exposing host or credentials."""
     parsed = urlsplit(stream_url)

--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -416,6 +416,21 @@
       padding-top: 1rem;
       border-top: 1px solid var(--border);
     }
+    .bridge-capture-picker {
+      margin-top: 0.75rem;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface-2);
+    }
+    .bridge-capture-picker input,
+    .bridge-capture-picker select {
+      box-sizing: border-box;
+      width: 100%;
+      margin-top: 0.55rem;
+    }
+    .bridge-capture-picker select { min-height: 9rem; }
+    .bridge-capture-picker .field-actions { margin-top: 0.6rem; }
     .bridge-fallback-details {
       margin-top: 1rem;
       padding-top: 0.85rem;

--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -755,6 +755,11 @@
     .bridge-healthcheck-title { font-weight: 650; color: var(--text); margin-bottom: 0.2rem; }
     .bridge-healthcheck-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; flex-shrink: 0; }
     .bridge-healthcheck-results { margin-top: 0.75rem; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+    .bridge-live-test-picker { margin-top: 0.75rem; padding: 0.85rem; border: 1px solid color-mix(in srgb, var(--warning-soft) 35%, var(--border)); border-radius: 8px; background: var(--surface-2); }
+    .bridge-live-test-picker label { display: block; margin-top: 0.7rem; font-size: 0.84rem; font-weight: 650; }
+    .bridge-live-test-picker select { box-sizing: border-box; width: 100%; margin-top: 0.35rem; }
+    .bridge-live-test-warning { color: var(--warning-soft); font-size: 0.84rem; line-height: 1.45; }
+    .bridge-live-test-picker .field-actions { margin-top: 0.65rem; }
     .bridge-healthcheck-summary { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 0.75rem 0.9rem; background: var(--surface-2); }
     .bridge-healthcheck-summary strong.ok { color: var(--success-soft); }
     .bridge-healthcheck-summary strong.warn { color: var(--warning-soft); }

--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -729,6 +729,30 @@
     }
     .needs-config-banner li.item-configured { color: var(--success-soft); }
     .needs-config-banner li.item-configured a { color: var(--success-soft); }
+
+    /* ── Bridge post-install healthcheck ── */
+    .bridge-healthcheck {
+      display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+      margin-top: 1rem; padding: 0.9rem 1rem;
+      background: color-mix(in srgb, var(--accent-bg) 48%, var(--surface));
+      border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border)); border-radius: 8px;
+    }
+    .bridge-healthcheck-title { font-weight: 650; color: var(--text); margin-bottom: 0.2rem; }
+    .bridge-healthcheck-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; flex-shrink: 0; }
+    .bridge-healthcheck-results { margin-top: 0.75rem; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+    .bridge-healthcheck-summary { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 0.75rem 0.9rem; background: var(--surface-2); }
+    .bridge-healthcheck-summary strong.ok { color: var(--success-soft); }
+    .bridge-healthcheck-summary strong.warn { color: var(--warning-soft); }
+    .bridge-healthcheck-summary strong.fail { color: var(--danger); }
+    .bridge-healthcheck-row { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 0.65rem; padding: 0.7rem 0.9rem; border-top: 1px solid var(--border); }
+    .bridge-healthcheck-icon { font-weight: 700; line-height: 1.35; }
+    .bridge-healthcheck-icon.ok { color: var(--success-soft); }
+    .bridge-healthcheck-icon.warn { color: var(--warning-soft); }
+    .bridge-healthcheck-icon.fail { color: var(--danger); }
+    .bridge-healthcheck-icon.skip, .bridge-healthcheck-icon.info { color: var(--text-muted); }
+    .bridge-healthcheck-name { font-size: 0.88rem; font-weight: 650; color: var(--text); }
+    .bridge-healthcheck-detail { margin-top: 0.18rem; color: var(--text-subtle); font-size: 0.83rem; line-height: 1.45; }
+    .bridge-healthcheck-fix { margin-top: 0.28rem; color: var(--warning-soft); font-size: 0.8rem; line-height: 1.4; }
     @media (max-width: 760px) {
       html { font-size: 16px; }
       nav { padding: 0.9rem 1rem; gap: 0.75rem 1rem; }
@@ -744,4 +768,5 @@
       .source-body { padding: 0 1rem 1rem; }
       .field-actions { flex-wrap: wrap; justify-content: flex-start; }
       .save-status { min-width: 0; text-align: left; }
+      .bridge-healthcheck { align-items: flex-start; flex-direction: column; }
     }

--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -773,6 +773,8 @@
     .bridge-healthcheck-name { font-size: 0.88rem; font-weight: 650; color: var(--text); }
     .bridge-healthcheck-detail { margin-top: 0.18rem; color: var(--text-subtle); font-size: 0.83rem; line-height: 1.45; }
     .bridge-healthcheck-fix { margin-top: 0.28rem; color: var(--warning-soft); font-size: 0.8rem; line-height: 1.4; }
+    .bridge-live-test-next { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 0.8rem 0.9rem; border-top: 1px solid var(--border); background: var(--surface-2); font-size: 0.86rem; }
+    .bridge-live-test-next.not-ready { opacity: 0.72; }
     @media (max-width: 760px) {
       html { font-size: 16px; }
       nav { padding: 0.9rem 1rem; gap: 0.75rem 1rem; }
@@ -789,4 +791,5 @@
       .field-actions { flex-wrap: wrap; justify-content: flex-start; }
       .save-status { min-width: 0; text-align: left; }
       .bridge-healthcheck { align-items: flex-start; flex-direction: column; }
+      .bridge-live-test-next { align-items: flex-start; flex-direction: column; }
     }

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -287,6 +287,57 @@ function chooseFcPlayerCaptureStream() {
   status.className = 'save-status ok';
 }
 
+const _fcPlayerCapturePlatformDefaults = {
+  linux: {video: 'video0', audio: 'hw:1,0', example: 'capture://v4l2/video0/hw:1,0/?framerate=60'},
+  macos: {video: '', audio: '', example: 'capture://avfoundation/USB Video/USB Digital Audio/?framerate=60'},
+  windows: {video: '', audio: '', example: 'capture://dshow/<video device>/<audio device>/?framerate=60'},
+};
+
+function updateFcPlayerCaptureSourceFields() {
+  const platform = document.getElementById('fc-player-capture-platform')?.value || 'linux';
+  const defaults = _fcPlayerCapturePlatformDefaults[platform];
+  const video = document.getElementById('fc-player-capture-video');
+  const audio = document.getElementById('fc-player-capture-audio');
+  const help = document.getElementById('fc-player-capture-source-help');
+  if (!defaults || !video || !audio || !help) return;
+  video.value = defaults.video;
+  audio.value = defaults.audio;
+  video.placeholder = platform === 'linux' ? 'video0' : 'Video device name';
+  audio.placeholder = platform === 'linux' ? 'hw:1,0' : 'Audio device name';
+  help.innerHTML = `Creates a Channels DVR <strong>HLS / Text</strong> source with ignored M3U channel numbering. Example: <code>${_escapeHtml(defaults.example)}</code>. Device names are from the computer running Channels DVR, not the FastChannels container.`;
+}
+
+async function createFcPlayerCaptureSource() {
+  const button = document.getElementById('fc-player-create-capture-source');
+  const status = document.getElementById('fc-player-encoder-status');
+  const original = button.textContent;
+  const payload = {
+    platform: document.getElementById('fc-player-capture-platform').value,
+    video: document.getElementById('fc-player-capture-video').value.trim(),
+    audio: document.getElementById('fc-player-capture-audio').value.trim(),
+    framerate: document.getElementById('fc-player-capture-framerate').value,
+  };
+  button.disabled = true;
+  button.textContent = 'Creating in Channels DVR…';
+  status.textContent = '';
+  try {
+    const response = await fetch('/api/settings/fc-player/create-capture-source', {
+      method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(payload),
+    });
+    const data = await response.json();
+    if (!response.ok) throw new Error(data.error || 'Could not create the capture source.');
+    if (data.stream_url) document.getElementById('fc-player-encoder-url').value = data.stream_url;
+    status.textContent = data.message || 'Capture source created.';
+    status.className = `save-status ${data.warning ? 'warning' : 'ok'}`;
+  } catch (error) {
+    status.textContent = error.message || 'Could not create the capture source.';
+    status.className = 'save-status error';
+  } finally {
+    button.disabled = false;
+    button.textContent = original;
+  }
+}
+
 async function saveFcPlayerIdleStopToggle() {
   const enabled = document.getElementById('fc-player-idle-stop-enabled').checked;
   await saveSettings({fc_player_idle_stop_enabled: enabled}, 'fc-player-status');

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -233,6 +233,60 @@ async function saveFcPlayerEncoderSettings() {
   if (ok) setTimeout(() => location.reload(), 700);
 }
 
+let _fcPlayerCaptureStreams = [];
+
+function renderFcPlayerCaptureStreamPicker(filter = '') {
+  const picker = document.getElementById('fc-player-capture-stream-picker');
+  if (!picker) return;
+  const needle = filter.trim().toLowerCase();
+  const matches = _fcPlayerCaptureStreams.filter((stream) =>
+    !needle || stream.label.toLowerCase().includes(needle));
+  const options = matches.map((stream, index) =>
+    `<option value="${index}">${_escapeHtml(stream.label)}</option>`).join('');
+  picker.innerHTML = `
+    <div class="help" style="margin-top:0.7rem">Choose the channel backed by your HDMI capture device. Likely capture/HDMI entries are shown first; this only fills the URL—select Save to keep it.</div>
+    <input type="search" id="fc-player-capture-stream-filter" placeholder="Filter by channel or capture-device name" value="${_escapeHtml(filter)}" oninput="renderFcPlayerCaptureStreamPicker(this.value)">
+    <select id="fc-player-capture-stream-select" size="6" ${matches.length ? '' : 'disabled'}>${options || '<option>No matching streams</option>'}</select>
+    <div class="field-actions"><button class="btn btn-secondary" onclick="chooseFcPlayerCaptureStream()" ${matches.length ? '' : 'disabled'}>Use selected stream</button></div>`;
+  picker._matches = matches;
+}
+
+async function findFcPlayerCaptureStream() {
+  const button = document.getElementById('fc-player-find-capture-stream');
+  const picker = document.getElementById('fc-player-capture-stream-picker');
+  const status = document.getElementById('fc-player-encoder-status');
+  const original = button.textContent;
+  button.disabled = true;
+  button.textContent = 'Reading Channels DVR…';
+  status.textContent = '';
+  try {
+    const response = await fetch('/api/settings/fc-player/capture-streams');
+    const data = await response.json();
+    if (!response.ok) throw new Error(data.error || 'Could not read Channels DVR streams.');
+    _fcPlayerCaptureStreams = data.streams || [];
+    picker.hidden = false;
+    renderFcPlayerCaptureStreamPicker();
+  } catch (error) {
+    status.textContent = error.message || 'Could not read Channels DVR streams.';
+    status.className = 'save-status error';
+  } finally {
+    button.disabled = false;
+    button.textContent = original;
+  }
+}
+
+function chooseFcPlayerCaptureStream() {
+  const picker = document.getElementById('fc-player-capture-stream-picker');
+  const select = document.getElementById('fc-player-capture-stream-select');
+  const stream = picker?._matches?.[Number(select?.value)];
+  if (!stream) return;
+  document.getElementById('fc-player-encoder-url').value = stream.stream_url;
+  picker.hidden = true;
+  const status = document.getElementById('fc-player-encoder-status');
+  status.textContent = `Selected ${stream.label}. Save to use it.`;
+  status.className = 'save-status ok';
+}
+
 async function saveFcPlayerIdleStopToggle() {
   const enabled = document.getElementById('fc-player-idle-stop-enabled').checked;
   await saveSettings({fc_player_idle_stop_enabled: enabled}, 'fc-player-status');

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -1861,6 +1861,9 @@ async function runBridgeHealthcheck() {
       const state = check.status || 'info';
       html += `<div class="bridge-healthcheck-row"><span class="bridge-healthcheck-icon ${_bridgeHealthcheckEsc(state)}">${icon[state] || '?'}</span><div><div class="bridge-healthcheck-name">${_bridgeHealthcheckEsc(check.name)}</div><div class="bridge-healthcheck-detail">${_bridgeHealthcheckEsc(check.detail)}</div>${check.fix ? `<div class="bridge-healthcheck-fix">Next step: ${_bridgeHealthcheckEsc(check.fix)}</div>` : ''}</div></div>`;
     }
+    const readyForLiveTest = checks.some(check => check.name === 'FastChannels Player device' && check.status === 'ok')
+      && checks.some(check => check.name === 'HDMI Capture payload' && check.status === 'ok');
+    html += `<div class="bridge-live-test-next ${readyForLiveTest ? '' : 'not-ready'}"><div><strong>Final confirmation: Live bridge test</strong><div class="help">${readyForLiveTest ? 'Tune one real bridge channel and verify the Player → HDMI Capture path. This interrupts the configured device.' : 'Available after the FastChannels Player device and HDMI Capture payload checks pass.'}</div></div><button class="btn btn-secondary" id="bridge-live-test-open" onclick="openBridgeLiveTest()" ${readyForLiveTest ? '' : 'disabled'}>Live bridge test…</button></div>`;
     results.innerHTML = html;
     if (copy && _lastBridgeHealthcheckReport) copy.disabled = false;
   } catch (error) {
@@ -1884,10 +1887,12 @@ let _bridgeLiveTestChannels = [];
 async function openBridgeLiveTest() {
   const button = document.getElementById('bridge-live-test-open');
   const picker = document.getElementById('bridge-live-test-picker');
-  if (!button || !picker) return;
-  const original = button.textContent;
-  button.disabled = true;
-  button.textContent = 'Loading channels…';
+  if (!picker) return;
+  const original = button?.textContent || 'Live bridge test…';
+  if (button) {
+    button.disabled = true;
+    button.textContent = 'Loading channels…';
+  }
   try {
     const response = await fetch('/api/settings/bridge/live-test-channels');
     const data = await response.json();
@@ -1906,8 +1911,10 @@ async function openBridgeLiveTest() {
     picker.hidden = false;
     picker.innerHTML = `<div class="bridge-healthcheck-detail" style="color:var(--danger)">${_bridgeHealthcheckEsc(error.message || error)}</div>`;
   } finally {
-    button.disabled = false;
-    button.textContent = original;
+    if (button) {
+      button.disabled = false;
+      button.textContent = original;
+    }
   }
 }
 

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -244,7 +244,7 @@ function renderFcPlayerCaptureStreamPicker(filter = '') {
   const options = matches.map((stream, index) =>
     `<option value="${index}">${_escapeHtml(stream.label)}</option>`).join('');
   picker.innerHTML = `
-    <div class="help" style="margin-top:0.7rem">Choose the channel backed by your HDMI capture device. Likely capture/HDMI entries are shown first; this only fills the URL—select Save to keep it.</div>
+    <div class="help" style="margin-top:0.7rem">Channels DVR returned ${_fcPlayerCaptureStreams.length} direct MPEG-TS stream${_fcPlayerCaptureStreams.length === 1 ? '' : 's'}. Choose the channel backed by your HDMI capture device. Likely capture/HDMI entries are shown first; this only fills the URL—select Save to keep it.</div>
     <input type="search" id="fc-player-capture-stream-filter" placeholder="Filter by channel or capture-device name" value="${_escapeHtml(filter)}" oninput="renderFcPlayerCaptureStreamPicker(this.value)">
     <select id="fc-player-capture-stream-select" size="6" ${matches.length ? '' : 'disabled'}>${options || '<option>No matching streams</option>'}</select>
     <div class="field-actions"><button class="btn btn-secondary" onclick="chooseFcPlayerCaptureStream()" ${matches.length ? '' : 'disabled'}>Use selected stream</button></div>`;

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -1778,6 +1778,53 @@ async function savePrismcastToggle() {
   setTimeout(() => location.reload(), 700);
 }
 
+let _lastBridgeHealthcheckReport = '';
+
+function _bridgeHealthcheckEsc(value) {
+  return String(value == null ? '' : value).replace(/[&<>"']/g, char => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  }[char]));
+}
+
+async function runBridgeHealthcheck() {
+  const run = document.getElementById('bridge-healthcheck-run');
+  const copy = document.getElementById('bridge-healthcheck-copy');
+  const results = document.getElementById('bridge-healthcheck-results');
+  if (!run || !results) return;
+  run.disabled = true;
+  if (copy) copy.disabled = true;
+  results.hidden = false;
+  results.innerHTML = '<div class="bridge-healthcheck-row"><span class="bridge-healthcheck-icon info">…</span><div><div class="bridge-healthcheck-name">Running healthcheck</div><div class="bridge-healthcheck-detail">Checking configured paths without tuning a channel…</div></div></div>';
+  try {
+    const response = await fetch('/api/settings/bridge/healthcheck', {method: 'POST'});
+    const data = await response.json();
+    if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
+    _lastBridgeHealthcheckReport = data.forum_report || '';
+    const icon = {ok: '✓', warn: '⚠', fail: '✗', skip: '–', info: 'ℹ'};
+    const checks = data.checks || [];
+    let html = `<div class="bridge-healthcheck-summary"><strong class="${_bridgeHealthcheckEsc(data.overall)}">${_bridgeHealthcheckEsc(data.overall_label || 'COMPLETE')}</strong><span class="help">${data.summary?.ok || 0} passed · ${data.summary?.warn || 0} warning${(data.summary?.warn || 0) === 1 ? '' : 's'} · ${data.summary?.fail || 0} failed</span></div>`;
+    for (const check of checks) {
+      const state = check.status || 'info';
+      html += `<div class="bridge-healthcheck-row"><span class="bridge-healthcheck-icon ${_bridgeHealthcheckEsc(state)}">${icon[state] || '?'}</span><div><div class="bridge-healthcheck-name">${_bridgeHealthcheckEsc(check.name)}</div><div class="bridge-healthcheck-detail">${_bridgeHealthcheckEsc(check.detail)}</div>${check.fix ? `<div class="bridge-healthcheck-fix">Next step: ${_bridgeHealthcheckEsc(check.fix)}</div>` : ''}</div></div>`;
+    }
+    results.innerHTML = html;
+    if (copy && _lastBridgeHealthcheckReport) copy.disabled = false;
+  } catch (error) {
+    results.innerHTML = `<div class="bridge-healthcheck-row"><span class="bridge-healthcheck-icon fail">✗</span><div><div class="bridge-healthcheck-name">Healthcheck could not run</div><div class="bridge-healthcheck-detail">${_bridgeHealthcheckEsc(error.message || error)}</div></div></div>`;
+  } finally {
+    run.disabled = false;
+  }
+}
+
+async function copyBridgeHealthcheck() {
+  if (!_lastBridgeHealthcheckReport) return;
+  try {
+    await navigator.clipboard.writeText(_lastBridgeHealthcheckReport);
+  } catch (_) {
+    window.prompt('Copy forum report', _lastBridgeHealthcheckReport);
+  }
+}
+
 async function testDvrConnection() {
   const statusEl = document.getElementById('dvr-settings-status');
   statusEl.textContent = 'Testing…';

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -1938,9 +1938,27 @@ async function runBridgeLiveTest() {
     const icon = state === 'ok' ? '✓' : (state === 'warn' ? '⚠' : '✗');
     const player = data.player_playing ? 'Player reports playback active' : (data.player_visible ? 'FastChannels Player is foreground' : 'Player did not report active playback');
     const focus = data.player_focus ? `<br>Device focus: ${_bridgeHealthcheckEsc(data.player_focus)}` : '';
-    picker.innerHTML = `<div class="bridge-healthcheck-row"><span class="bridge-healthcheck-icon ${state}">${icon}</span><div><div class="bridge-healthcheck-name">Live bridge test: ${_bridgeHealthcheckEsc(data.channel || channel.label)}</div><div class="bridge-healthcheck-detail">${_bridgeHealthcheckEsc(data.detail || '')}<br>Endpoint: ${_bridgeHealthcheckEsc(data.endpoint || '')}<br>Capture: ${_bridgeHealthcheckEsc(String(data.bytes_received || 0))} bytes in ${_bridgeHealthcheckEsc(String(data.elapsed_ms || 0))} ms (${_bridgeHealthcheckEsc(data.content_type || 'unspecified')})<br>${_bridgeHealthcheckEsc(player)}${focus}</div></div></div>`;
+    picker.innerHTML = `<div class="bridge-healthcheck-row"><span class="bridge-healthcheck-icon ${state}">${icon}</span><div><div class="bridge-healthcheck-name">Live bridge test: ${_bridgeHealthcheckEsc(data.channel || channel.label)}</div><div class="bridge-healthcheck-detail">${_bridgeHealthcheckEsc(data.detail || '')}<br>Endpoint: ${_bridgeHealthcheckEsc(data.endpoint || '')}<br>Capture: ${_bridgeHealthcheckEsc(String(data.bytes_received || 0))} bytes in ${_bridgeHealthcheckEsc(String(data.elapsed_ms || 0))} ms (${_bridgeHealthcheckEsc(data.content_type || 'unspecified')})<br>Media: ${_bridgeHealthcheckEsc(data.media_summary || 'Not available')}<br>${_bridgeHealthcheckEsc(player)}${focus}</div><div class="field-actions"><button class="btn btn-secondary" id="bridge-live-test-stop" onclick="stopBridgeLiveTest()">Stop test playback</button></div></div></div>`;
   } catch (error) {
     picker.innerHTML = `<div class="bridge-healthcheck-row"><span class="bridge-healthcheck-icon fail">✗</span><div><div class="bridge-healthcheck-name">Live bridge test failed</div><div class="bridge-healthcheck-detail">${_bridgeHealthcheckEsc(error.message || error)}</div></div></div>`;
+  }
+}
+
+async function stopBridgeLiveTest() {
+  const button = document.getElementById('bridge-live-test-stop');
+  if (!button) return;
+  const original = button.textContent;
+  button.disabled = true;
+  button.textContent = 'Stopping…';
+  try {
+    const response = await fetch('/api/settings/bridge/live-test/stop', {method: 'POST'});
+    const data = await response.json();
+    if (!response.ok) throw new Error(data.error || 'Could not stop Player playback.');
+    button.textContent = data.message || 'Playback stopped';
+  } catch (error) {
+    button.disabled = false;
+    button.textContent = original;
+    window.alert(error.message || error);
   }
 }
 

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -1879,6 +1879,64 @@ async function copyBridgeHealthcheck() {
   }
 }
 
+let _bridgeLiveTestChannels = [];
+
+async function openBridgeLiveTest() {
+  const button = document.getElementById('bridge-live-test-open');
+  const picker = document.getElementById('bridge-live-test-picker');
+  if (!button || !picker) return;
+  const original = button.textContent;
+  button.disabled = true;
+  button.textContent = 'Loading channels…';
+  try {
+    const response = await fetch('/api/settings/bridge/live-test-channels');
+    const data = await response.json();
+    if (!response.ok) throw new Error(data.error || 'Could not load bridge channels.');
+    _bridgeLiveTestChannels = data.channels || [];
+    picker.hidden = false;
+    if (!_bridgeLiveTestChannels.length) {
+      picker.innerHTML = '<div class="help">No active, enabled channels are currently marked for bridge output. Run Stream Audit on a DRM source first.</div>';
+      return;
+    }
+    picker.innerHTML = `<div class="bridge-live-test-warning"><strong>Live bridge test will change what is playing on the configured HDMI Capture device.</strong> It triggers one real bridge channel, waits briefly, and verifies the saved capture stream from inside FastChannels.</div>
+      <label for="bridge-live-test-channel">Bridge channel to tune</label>
+      <select id="bridge-live-test-channel">${_bridgeLiveTestChannels.map(channel => `<option value="${channel.id}">${_bridgeHealthcheckEsc(channel.label)}</option>`).join('')}</select>
+      <div class="field-actions"><button class="btn btn-primary" id="bridge-live-test-run" onclick="runBridgeLiveTest()">Start live test</button></div>`;
+  } catch (error) {
+    picker.hidden = false;
+    picker.innerHTML = `<div class="bridge-healthcheck-detail" style="color:var(--danger)">${_bridgeHealthcheckEsc(error.message || error)}</div>`;
+  } finally {
+    button.disabled = false;
+    button.textContent = original;
+  }
+}
+
+async function runBridgeLiveTest() {
+  const select = document.getElementById('bridge-live-test-channel');
+  const run = document.getElementById('bridge-live-test-run');
+  const picker = document.getElementById('bridge-live-test-picker');
+  const channel = _bridgeLiveTestChannels.find(item => item.id === Number(select?.value));
+  if (!channel || !run || !picker) return;
+  if (!window.confirm(`Tune ${channel.label} on the HDMI Capture device now? This will interrupt anything currently playing there.`)) return;
+  run.disabled = true;
+  run.textContent = 'Tuning device and sampling capture…';
+  try {
+    const response = await fetch('/api/settings/bridge/live-test', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({channel_id: channel.id}),
+    });
+    const data = await response.json();
+    if (!response.ok) throw new Error(data.error || data.detail || `HTTP ${response.status}`);
+    const state = data.status || (data.ok ? 'ok' : 'fail');
+    const icon = state === 'ok' ? '✓' : (state === 'warn' ? '⚠' : '✗');
+    const player = data.player_playing ? 'Player reports playback active' : (data.player_visible ? 'FastChannels Player is foreground' : 'Player did not report active playback');
+    const focus = data.player_focus ? `<br>Device focus: ${_bridgeHealthcheckEsc(data.player_focus)}` : '';
+    picker.innerHTML = `<div class="bridge-healthcheck-row"><span class="bridge-healthcheck-icon ${state}">${icon}</span><div><div class="bridge-healthcheck-name">Live bridge test: ${_bridgeHealthcheckEsc(data.channel || channel.label)}</div><div class="bridge-healthcheck-detail">${_bridgeHealthcheckEsc(data.detail || '')}<br>Endpoint: ${_bridgeHealthcheckEsc(data.endpoint || '')}<br>Capture: ${_bridgeHealthcheckEsc(String(data.bytes_received || 0))} bytes in ${_bridgeHealthcheckEsc(String(data.elapsed_ms || 0))} ms (${_bridgeHealthcheckEsc(data.content_type || 'unspecified')})<br>${_bridgeHealthcheckEsc(player)}${focus}</div></div></div>`;
+  } catch (error) {
+    picker.innerHTML = `<div class="bridge-healthcheck-row"><span class="bridge-healthcheck-icon fail">✗</span><div><div class="bridge-healthcheck-name">Live bridge test failed</div><div class="bridge-healthcheck-detail">${_bridgeHealthcheckEsc(error.message || error)}</div></div></div>`;
+  }
+}
+
 async function testDvrConnection() {
   const statusEl = document.getElementById('dvr-settings-status');
   statusEl.textContent = 'Testing…';

--- a/app/templates/admin/bridge.html
+++ b/app/templates/admin/bridge.html
@@ -48,7 +48,6 @@
           </div>
           <div class="bridge-healthcheck-actions">
             <button class="btn btn-secondary" id="bridge-healthcheck-copy" onclick="copyBridgeHealthcheck()" disabled>Copy forum report</button>
-            <button class="btn btn-secondary" id="bridge-live-test-open" onclick="openBridgeLiveTest()">Live bridge test…</button>
             <button class="btn btn-primary" id="bridge-healthcheck-run" onclick="runBridgeHealthcheck()">Run healthcheck</button>
           </div>
         </div>

--- a/app/templates/admin/bridge.html
+++ b/app/templates/admin/bridge.html
@@ -44,14 +44,16 @@
         <div class="bridge-healthcheck">
           <div class="bridge-healthcheck-copy">
             <div class="bridge-healthcheck-title">Post-install Healthcheck</div>
-            <div class="help">Checks Bridge mode, the FastChannels Player device, HDMI Capture—including a small capture-payload sample from inside Docker—and ah4c tuners without tuning a channel or changing a device. PrismCast keeps its own deeper capture test below.</div>
+            <div class="help">Checks Bridge mode, the FastChannels Player device, HDMI Capture—including a small capture-payload sample from inside Docker—and ah4c tuners without tuning a channel or changing a device. For a deliberate end-to-end tune, use Live bridge test. PrismCast keeps its own deeper capture test below.</div>
           </div>
           <div class="bridge-healthcheck-actions">
             <button class="btn btn-secondary" id="bridge-healthcheck-copy" onclick="copyBridgeHealthcheck()" disabled>Copy forum report</button>
+            <button class="btn btn-secondary" id="bridge-live-test-open" onclick="openBridgeLiveTest()">Live bridge test…</button>
             <button class="btn btn-primary" id="bridge-healthcheck-run" onclick="runBridgeHealthcheck()">Run healthcheck</button>
           </div>
         </div>
         <div id="bridge-healthcheck-results" class="bridge-healthcheck-results" hidden aria-live="polite"></div>
+        <div id="bridge-live-test-picker" class="bridge-live-test-picker" hidden></div>
         <div class="bridge-audit-note">
           <strong>First-time setup:</strong> after enabling a bridge method, run a <strong>Stream Audit</strong> for each source you intend to bridge. The audit detects DRM and marks eligible channels for bridge output; without it, existing channels may still look like ordinary or disabled streams.
           <a href="/admin/sources">Open Sources and run audits →</a>

--- a/app/templates/admin/bridge.html
+++ b/app/templates/admin/bridge.html
@@ -44,7 +44,7 @@
         <div class="bridge-healthcheck">
           <div class="bridge-healthcheck-copy">
             <div class="bridge-healthcheck-title">Post-install Healthcheck</div>
-            <div class="help">Checks Bridge mode, the FastChannels Player device, HDMI Capture, and ah4c tuners without tuning a channel or changing a device. PrismCast keeps its own deeper capture test below.</div>
+            <div class="help">Checks Bridge mode, the FastChannels Player device, HDMI Capture—including a small capture-payload sample from inside Docker—and ah4c tuners without tuning a channel or changing a device. PrismCast keeps its own deeper capture test below.</div>
           </div>
           <div class="bridge-healthcheck-actions">
             <button class="btn btn-secondary" id="bridge-healthcheck-copy" onclick="copyBridgeHealthcheck()" disabled>Copy forum report</button>

--- a/app/templates/admin/bridge.html
+++ b/app/templates/admin/bridge.html
@@ -41,6 +41,17 @@
         {% if (prismcast_enabled or fc_player_enabled) and not bridge_enabled and drm_bridge_recoverable_count %}
         <div class="help" style="color:var(--accent-soft)">💡 A bridge method is enabled and {{ drm_bridge_recoverable_count }} DRM channel{{ 's' if drm_bridge_recoverable_count != 1 else '' }} {{ 'is' if drm_bridge_recoverable_count == 1 else 'are' }} currently disabled. Turn on Bridge mode to recover {{ 'it' if drm_bridge_recoverable_count == 1 else 'them' }}.</div>
         {% endif %}
+        <div class="bridge-healthcheck">
+          <div class="bridge-healthcheck-copy">
+            <div class="bridge-healthcheck-title">Post-install Healthcheck</div>
+            <div class="help">Checks Bridge mode, the FastChannels Player device, HDMI Capture, and ah4c tuners without tuning a channel or changing a device. PrismCast keeps its own deeper capture test below.</div>
+          </div>
+          <div class="bridge-healthcheck-actions">
+            <button class="btn btn-secondary" id="bridge-healthcheck-copy" onclick="copyBridgeHealthcheck()" disabled>Copy forum report</button>
+            <button class="btn btn-primary" id="bridge-healthcheck-run" onclick="runBridgeHealthcheck()">Run healthcheck</button>
+          </div>
+        </div>
+        <div id="bridge-healthcheck-results" class="bridge-healthcheck-results" hidden aria-live="polite"></div>
         <div class="bridge-audit-note">
           <strong>First-time setup:</strong> after enabling a bridge method, run a <strong>Stream Audit</strong> for each source you intend to bridge. The audit detects DRM and marks eligible channels for bridge output; without it, existing channels may still look like ordinary or disabled streams.
           <a href="/admin/sources">Open Sources and run audits →</a>

--- a/app/templates/admin/bridge/single_encoder.html
+++ b/app/templates/admin/bridge/single_encoder.html
@@ -66,6 +66,34 @@
       <div class="field-actions"><span class="save-status" id="fc-player-encoder-status"></span><button class="btn btn-secondary" id="fc-player-find-capture-stream" onclick="findFcPlayerCaptureStream()">Find from Channels DVR</button><button class="btn btn-secondary" onclick="testFcPlayer()">Test connection</button><button class="btn btn-primary" onclick="saveFcPlayerEncoderSettings()">Save</button></div>
       <div id="fc-player-capture-stream-picker" class="bridge-capture-picker" hidden></div>
       <details class="help" style="margin-top:0.65rem">
+        <summary style="cursor:pointer">No camera source in Channels DVR yet?</summary>
+        <div style="margin-top:0.65rem">Create a native USB/HDMI capture source in Channels DVR, then FastChannels will select its exported stream automatically. Confirm the new capture channel plays in Channels before relying on it for bridge playback.</div>
+        <div class="fields-grid" style="max-width:480px;margin-top:0.65rem">
+          <div class="field">
+            <label for="fc-player-capture-platform">DVR platform</label>
+            <select id="fc-player-capture-platform" onchange="updateFcPlayerCaptureSourceFields()">
+              <option value="linux">Linux</option>
+              <option value="macos">macOS</option>
+              <option value="windows">Windows</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="fc-player-capture-framerate">Frame rate</label>
+            <input id="fc-player-capture-framerate" type="number" min="1" max="120" value="60">
+          </div>
+          <div class="field">
+            <label for="fc-player-capture-video">Video device</label>
+            <input id="fc-player-capture-video" value="video0" placeholder="video0">
+          </div>
+          <div class="field">
+            <label for="fc-player-capture-audio">Audio device</label>
+            <input id="fc-player-capture-audio" value="hw:1,0" placeholder="hw:1,0">
+          </div>
+        </div>
+        <div class="help" id="fc-player-capture-source-help" style="margin-top:0.45rem">Uses <code>capture://v4l2/video0/hw:1,0/?framerate=60</code>. Device names are from the computer running Channels DVR, not the FastChannels container.</div>
+        <div class="field-actions"><button class="btn btn-secondary" id="fc-player-create-capture-source" onclick="createFcPlayerCaptureSource()">Add FastChannels Capture Card to Channels DVR</button></div>
+      </details>
+      <details class="help" style="margin-top:0.65rem">
         <summary style="cursor:pointer">Need to paste it manually instead?</summary>
         In Channels DVR, open <strong>Manage → Export → Copy M3U</strong>, open that URL, then copy the non-comment <code>/stream.mpg</code> line directly below your capture channel's <code>#EXTINF</code> entry. Paste it above and save.
       </details>

--- a/app/templates/admin/bridge/single_encoder.html
+++ b/app/templates/admin/bridge/single_encoder.html
@@ -60,10 +60,15 @@
         <div class="field field-full">
           <label for="fc-player-encoder-url">Capture/encoder stream URL</label>
           <input type="text" id="fc-player-encoder-url" placeholder="http://192.168.1.50:8089/devices/ANY/channels/70092/stream.mpg" value="{{ fc_player_encoder_url }}">
-          <div class="help">Where the captured bridge stream is read after the Player device is triggered.</div>
+          <div class="help">Where the captured bridge stream is read after the Player device is triggered. If the capture device is in Channels DVR, use the picker below instead of copying an M3U entry by hand.</div>
         </div>
       </div>
-      <div class="field-actions"><span class="save-status" id="fc-player-encoder-status"></span><button class="btn btn-secondary" onclick="testFcPlayer()">Test connection</button><button class="btn btn-primary" onclick="saveFcPlayerEncoderSettings()">Save</button></div>
+      <div class="field-actions"><span class="save-status" id="fc-player-encoder-status"></span><button class="btn btn-secondary" id="fc-player-find-capture-stream" onclick="findFcPlayerCaptureStream()">Find from Channels DVR</button><button class="btn btn-secondary" onclick="testFcPlayer()">Test connection</button><button class="btn btn-primary" onclick="saveFcPlayerEncoderSettings()">Save</button></div>
+      <div id="fc-player-capture-stream-picker" class="bridge-capture-picker" hidden></div>
+      <details class="help" style="margin-top:0.65rem">
+        <summary style="cursor:pointer">Need to paste it manually instead?</summary>
+        In Channels DVR, open <strong>Manage → Export → Copy M3U</strong>, open that URL, then copy the non-comment <code>/stream.mpg</code> line directly below your capture channel's <code>#EXTINF</code> entry. Paste it above and save.
+      </details>
     </div>
   </div>
 </div>

--- a/docs/fc-player-setup.md
+++ b/docs/fc-player-setup.md
@@ -161,7 +161,8 @@ be saved for the install button below to work.
 
 Before attempting a real bridge-only channel, use **Bridge → Post-install
 Healthcheck → Run healthcheck**. It checks the configured hardware paths
-without tuning a channel, and **Copy forum report** creates a concise,
+without tuning a channel, samples the configured HDMI Capture stream from
+inside the FastChannels container, and **Copy forum report** creates a concise,
 credential-free report to attach to a support post. PrismCast has its own
 specialized capture test in the PrismCast Capture card.
 

--- a/docs/fc-player-setup.md
+++ b/docs/fc-player-setup.md
@@ -159,6 +159,12 @@ In the **HDMI Capture** card, complete:
 Click **Save** in that section before continuing — the device IP must already
 be saved for the install button below to work.
 
+Before attempting a real bridge-only channel, use **Bridge → Post-install
+Healthcheck → Run healthcheck**. It checks the configured hardware paths
+without tuning a channel, and **Copy forum report** creates a concise,
+credential-free report to attach to a support post. PrismCast has its own
+specialized capture test in the PrismCast Capture card.
+
 The automatic stop option detects viewers using Channels DVR's activity status
 or the FastChannels `/watch` page. It cannot detect a third-party player
 connected directly to the M3U. Leave this option off if you watch that way.

--- a/docs/fc-player-setup.md
+++ b/docs/fc-player-setup.md
@@ -179,6 +179,13 @@ inside the FastChannels container, and **Copy forum report** creates a concise,
 credential-free report to attach to a support post. PrismCast has its own
 specialized capture test in the PrismCast Capture card.
 
+When the non-disruptive check passes, **Live bridge test** is the optional
+end-to-end confirmation: choose one bridge-ready channel, confirm the warning,
+and FastChannels tunes the Player device then samples the HDMI Capture stream.
+It intentionally interrupts anything playing on that device. The result shows
+the tested stream path, payload size, timing, and whether the Player reports
+active playback.
+
 The automatic stop option detects viewers using Channels DVR's activity status
 or the FastChannels `/watch` page. It cannot detect a third-party player
 connected directly to the M3U. Leave this option off if you watch that way.

--- a/docs/fc-player-setup.md
+++ b/docs/fc-player-setup.md
@@ -75,16 +75,29 @@ For a capture setup walkthrough, see the first two posts here:
 
 Once the capture source appears as a device in Channels DVR:
 
+1. In FastChannels, configure the **Channels DVR URL** under **Settings**.
+2. In the **HDMI Capture** card, select **Find from Channels DVR**.
+3. Search for and select the channel backed by the HDMI capture device, then
+   select **Use selected stream**. Capture/HDMI-like names are shown first.
+4. Select **Save** in the HDMI Capture card.
+
+FastChannels reads Channels DVR's MPEG-TS export itself, preserves any session
+parameter it needs, and uses the DVR address configured in FastChannels rather
+than a potentially unusable `localhost` address from the export.
+
+If the picker cannot reach a remote or separately authenticated DVR, retrieve
+the direct URL manually:
+
 1. Find the capture source card in the Channels DVR admin interface.
-2. Select **Manage → Export → Copy M3U**.
-3. Download the M3U and open it in a text editor.
-4. Copy the full stream URL on the second line. It should look similar to:
+2. Select **Manage → Export → Copy M3U** and open that URL.
+3. Copy the non-comment stream URL immediately below the capture channel's
+   `#EXTINF` line. It should look similar to:
 
    ```text
    http://<host>:8089/devices/<YourDevice>/channels/<N>/stream.mpg?format=ts&codec=copy
    ```
 
-5. Test the URL by opening it in a browser or media player. It should begin
+4. Test the URL by opening it in a browser or media player. It should begin
    returning video without redirecting to another playlist.
 
 Save this URL. You will enter it as the **Capture/encoder stream URL** later.

--- a/docs/fc-player-setup.md
+++ b/docs/fc-player-setup.md
@@ -184,7 +184,9 @@ end-to-end confirmation: choose one bridge-ready channel, confirm the warning,
 and FastChannels tunes the Player device then samples the HDMI Capture stream.
 It intentionally interrupts anything playing on that device. The result shows
 the tested stream path, payload size, timing, and whether the Player reports
-active playback.
+active playback. It also reports the MPEG-TS program's detected video/audio
+types when they appear in the short sample. Select **Stop test playback** when
+you are done to close the Player immediately.
 
 The automatic stop option detects viewers using Channels DVR's activity status
 or the FastChannels `/watch` page. It cannot detect a third-party player


### PR DESCRIPTION
## Summary
- Add one non-disruptive Bridge Healthcheck at the top of the Bridge page, with individual HDMI Capture and ah4c Capture results.
- Add a concise copy-to-clipboard forum report that contains no IP addresses, URLs, or credentials.
- Check Bridge mode, audited bridge-source count, FastChannels Player ADB/app availability, HDMI encoder reachability, and ah4c tuner authorization.
- Leave PrismCast's existing specialized browser/live-capture diagnostic untouched; the healthcheck links users to it instead.
- Document the recommended healthcheck step in the hardware-capture setup guide.

## Validation
- Python syntax parse and JavaScript syntax check passed.
- Restarted the local test container.
- Healthcheck returned READY: Bridge mode, 3 sources / 1196 bridge candidates, Player device, HDMI encoder, and 1/1 ah4c tuner passed; disabled PrismCast correctly skipped.

## Review focus
- Confirm the healthcheck is non-disruptive and that its forum report does not reveal sensitive configuration.
- Check the skip/warn/fail behavior for intentionally unused capture methods.