### PR TITLE
Added option to exclude FAST channels from DirecTV and Sling

### DIFF
--- a/app/routes/api_sources.py
+++ b/app/routes/api_sources.py
@@ -535,10 +535,11 @@ def save_source_config(source_id):
     def _toggle_enabled(cfg: dict, key: str) -> bool:
         return str(cfg.get(key, '')).strip().lower() in {'1', 'true', 'yes', 'on'}
 
-    # Sling's subscription and FAST-exclusion toggles change the channel
-    # inventory, not just a playback preference. Clear the derived account
-    # context on either edge so enabling subscriptions cannot reuse an
-    # expired/old account lineup.
+    # Both toggles change the lineup. Only a subscription-mode change needs
+    # the existing auth reset; FAST filtering must preserve the browser login.
+    sling_subscription_changed = source.name == 'sling' and (
+        _toggle_enabled(old, 'include_subscription_channels') != _toggle_enabled(current, 'include_subscription_channels')
+    )
     sling_lineup_changed = source.name == 'sling' and (
         _toggle_enabled(old, 'include_subscription_channels') != _toggle_enabled(current, 'include_subscription_channels')
         or _toggle_enabled(old, 'exclude_fast_channels') != _toggle_enabled(current, 'exclude_fast_channels')
@@ -550,7 +551,7 @@ def save_source_config(source_id):
         source.name == 'directv'
         and _toggle_enabled(old, 'exclude_fast_channels') != _toggle_enabled(current, 'exclude_fast_channels')
     )
-    if creds_changed or sling_lineup_changed:
+    if creds_changed or sling_subscription_changed:
         for tk in _AUTH_STATE:
             if data.get(tk) in (None, '', '••••••••'):  # skip values set in this save
                 current.pop(tk, None)
@@ -583,36 +584,6 @@ def save_source_config(source_id):
                         db.session.delete(ch)
                         pbs_deleted += 1
 
-    # Enabling "exclude FAST channels" only stops *new* FAST channels from being
-    # scraped in — existing rows still ride out the normal miss-threshold grace
-    # period (see PBS comment above) unless the paired "remove immediately"
-    # toggle is also on, in which case delete the matching rows here instead of
-    # waiting ~3 scrapes for them to quietly age out. Re-triggers whenever either
-    # toggle just turned on (not just on the exclude edge), so turning on "remove
-    # immediately" after the fact still purges retroactively.
-    fast_purged = 0
-    if source.name in ('sling', 'directv'):
-        new_exclude = _toggle_enabled(current, 'exclude_fast_channels')
-        new_purge   = _toggle_enabled(current, 'purge_fast_channels')
-        old_exclude = _toggle_enabled(old, 'exclude_fast_channels')
-        old_purge   = _toggle_enabled(old, 'purge_fast_channels')
-        if new_exclude and new_purge and (not old_exclude or not old_purge):
-            if source.name == 'sling':
-                from ..scrapers.sling import SlingScraper
-                def _is_fast(ch):
-                    return SlingScraper.FREESTREAM_TAG in {t.strip() for t in (ch.tags or '').split(',')}
-            else:
-                from ..scrapers.directv import DirectvScraper
-                def _is_fast(ch):
-                    # NOT ch.number — that's FastChannels' own reassigned guide
-                    # number (see worker.py's renumbering pass), unrelated to
-                    # DirecTV's real channel number the scraper tags against.
-                    return DirectvScraper.FAST_TAG in {t.strip() for t in (ch.tags or '').split(',')}
-            for ch in Channel.query.filter(Channel.source_id == source.id).all():
-                if _is_fast(ch):
-                    db.session.delete(ch)
-                    fast_purged += 1
-
     source.config = current
     auto_enabled = False
     if (
@@ -624,7 +595,7 @@ def save_source_config(source_id):
         source.is_enabled = True
         auto_enabled = True
     db.session.commit()
-    if pbs_deleted or fast_purged:
+    if pbs_deleted:
         _invalidate_and_refresh_xml()
     full_scrape_queued = False
     if source.name == 'sling' and (creds_changed or sling_lineup_changed) and source.is_enabled:
@@ -1160,4 +1131,3 @@ def directv_auth_status(source_id):
                 logger.error('[directv-auth] failed to persist result: %s', exc)
 
     return jsonify(data)
-

--- a/app/routes/api_sources.py
+++ b/app/routes/api_sources.py
@@ -532,17 +532,23 @@ def save_source_config(source_id):
         f.key in _CRED_KEYS and _norm_cred(f.key, old.get(f.key)) != _norm_cred(f.key, current.get(f.key))
         for f in schema
     )
-    def _sling_subscriptions_enabled(cfg: dict) -> bool:
-        return str(cfg.get('include_subscription_channels', '')).strip().lower() in {
-            '1', 'true', 'yes', 'on'
-        }
+    def _toggle_enabled(cfg: dict, key: str) -> bool:
+        return str(cfg.get(key, '')).strip().lower() in {'1', 'true', 'yes', 'on'}
 
-    # Sling's subscription toggle changes the channel inventory, not just a
-    # playback preference. Clear the derived account context on either edge so
-    # enabling it cannot reuse an expired/old account lineup.
-    sling_lineup_changed = (
-        source.name == 'sling'
-        and _sling_subscriptions_enabled(old) != _sling_subscriptions_enabled(current)
+    # Sling's subscription and FAST-exclusion toggles change the channel
+    # inventory, not just a playback preference. Clear the derived account
+    # context on either edge so enabling subscriptions cannot reuse an
+    # expired/old account lineup.
+    sling_lineup_changed = source.name == 'sling' and (
+        _toggle_enabled(old, 'include_subscription_channels') != _toggle_enabled(current, 'include_subscription_channels')
+        or _toggle_enabled(old, 'exclude_fast_channels') != _toggle_enabled(current, 'exclude_fast_channels')
+    )
+    # DirecTV's FAST-exclusion toggle likewise changes the channel inventory
+    # (filters out the 4xxx FAST channel-number range) rather than a playback
+    # preference, so it also needs an immediate rescrape below.
+    directv_lineup_changed = (
+        source.name == 'directv'
+        and _toggle_enabled(old, 'exclude_fast_channels') != _toggle_enabled(current, 'exclude_fast_channels')
     )
     if creds_changed or sling_lineup_changed:
         for tk in _AUTH_STATE:
@@ -577,6 +583,36 @@ def save_source_config(source_id):
                         db.session.delete(ch)
                         pbs_deleted += 1
 
+    # Enabling "exclude FAST channels" only stops *new* FAST channels from being
+    # scraped in — existing rows still ride out the normal miss-threshold grace
+    # period (see PBS comment above) unless the paired "remove immediately"
+    # toggle is also on, in which case delete the matching rows here instead of
+    # waiting ~3 scrapes for them to quietly age out. Re-triggers whenever either
+    # toggle just turned on (not just on the exclude edge), so turning on "remove
+    # immediately" after the fact still purges retroactively.
+    fast_purged = 0
+    if source.name in ('sling', 'directv'):
+        new_exclude = _toggle_enabled(current, 'exclude_fast_channels')
+        new_purge   = _toggle_enabled(current, 'purge_fast_channels')
+        old_exclude = _toggle_enabled(old, 'exclude_fast_channels')
+        old_purge   = _toggle_enabled(old, 'purge_fast_channels')
+        if new_exclude and new_purge and (not old_exclude or not old_purge):
+            if source.name == 'sling':
+                from ..scrapers.sling import SlingScraper
+                def _is_fast(ch):
+                    return SlingScraper.FREESTREAM_TAG in {t.strip() for t in (ch.tags or '').split(',')}
+            else:
+                from ..scrapers.directv import DirectvScraper
+                def _is_fast(ch):
+                    # NOT ch.number — that's FastChannels' own reassigned guide
+                    # number (see worker.py's renumbering pass), unrelated to
+                    # DirecTV's real channel number the scraper tags against.
+                    return DirectvScraper.FAST_TAG in {t.strip() for t in (ch.tags or '').split(',')}
+            for ch in Channel.query.filter(Channel.source_id == source.id).all():
+                if _is_fast(ch):
+                    db.session.delete(ch)
+                    fast_purged += 1
+
     source.config = current
     auto_enabled = False
     if (
@@ -588,13 +624,18 @@ def save_source_config(source_id):
         source.is_enabled = True
         auto_enabled = True
     db.session.commit()
-    if pbs_deleted:
+    if pbs_deleted or fast_purged:
         _invalidate_and_refresh_xml()
     full_scrape_queued = False
     if source.name == 'sling' and (creds_changed or sling_lineup_changed) and source.is_enabled:
-        # Credentials and the subscription toggle can add/remove channels.
-        # A normal scheduled scrape may be EPG-only for other sources, so make
-        # this refresh deterministic and immediate after the config commit.
+        # Credentials and the subscription/FAST-exclusion toggles can add/remove
+        # channels. A normal scheduled scrape may be EPG-only for other sources,
+        # so make this refresh deterministic and immediate after the config commit.
+        trigger_scrape(source.name, force_full=True)
+        full_scrape_queued = True
+    elif source.name == 'directv' and directv_lineup_changed and source.is_enabled:
+        # Same rationale as Sling above — the FAST-exclusion toggle changes
+        # which channels come back from fetch_channels().
         trigger_scrape(source.name, force_full=True)
         full_scrape_queued = True
     elif source.name == 'pbs' and old != current and source.is_enabled:

--- a/app/scrapers/base.py
+++ b/app/scrapers/base.py
@@ -531,6 +531,10 @@ class BaseScraper(ABC):
     under_development: bool = False  # shown in the admin UI; source remains opt-in
     channel_refresh_hours: int = 0   # 0 = refresh channels every run; >0 = only refresh channels after N hours
     channel_miss_threshold: int = 3  # missed scrapes before is_active=False; override per scraper
+    # Reset/populate per fetch_channels() with upstream IDs intentionally
+    # filtered out. Reconciliation deactivates existing rows without deleting
+    # user settings and excludes these IDs from the lineup-collapse guard.
+    excluded_channel_ids: set[str] | frozenset[str] = frozenset()
     pinned_channel_ids: frozenset = frozenset()  # source_channel_ids born (and kept) scrape_pinned=True — exempt from channel_miss_threshold; for channels that are expected to be intermittently absent from a scrape by design (e.g. a rotating best-effort discovery), not just resilient-by-default
     rehome_by_guide_key: bool = False  # when True, re-use existing DB rows whose guide_key matches an incoming channel whose uuid changed
 

--- a/app/scrapers/directv.py
+++ b/app/scrapers/directv.py
@@ -1369,7 +1369,23 @@ class DirectvScraper(BaseScraper):
         ConfigField('password', 'Password', field_type='password', required=True,
                     secret=True,
                     help_text='Your DirecTV Stream password.'),
+        ConfigField('exclude_fast_channels', 'Exclude FAST channels',
+                    field_type='toggle', default='false',
+                    help_text=(
+                        'On = leave out free, ad-supported channels. '
+                        'DirecTV Stream puts these in the 4000-4999 channel number range.'
+                    )),
+        ConfigField('purge_fast_channels', 'Remove existing FAST channels immediately',
+                    field_type='toggle', default='false',
+                    help_text=(
+                        'On = when you enable the exclusion above, also delete previously-scraped 4xxx '
+                        'channels right away. Off = they stay listed and quietly age out over the next few scrapes.'
+                    )),
     ]
+
+    # Also referenced by api_sources.py's immediate-purge path.
+    _FAST_CHANNEL_NUMBER_RANGE = range(4000, 5000)
+    FAST_TAG = 'DirecTV FAST'
 
     def __init__(self, config: dict | None = None):
         super().__init__(config)
@@ -1392,6 +1408,9 @@ class DirectvScraper(BaseScraper):
                 )
             except Exception:
                 continue
+
+    def _exclude_fast_channels(self) -> bool:
+        return str(self.config.get('exclude_fast_channels', '')).strip().lower() in {'1', 'true', 'yes', 'on'}
 
     # ── Auth ─────────────────────────────────────────────────────────────────
 
@@ -1519,6 +1538,7 @@ class DirectvScraper(BaseScraper):
         if not rows:
             raise ScrapeSkipError('DirecTV Stream: could not find a channel list in the AllChannels response')
 
+        exclude_fast = self._exclude_fast_channels()
         channels: list[ChannelData] = []
 
         for row in rows:
@@ -1530,6 +1550,13 @@ class DirectvScraper(BaseScraper):
 
             number_raw = _pick(row, 'channelNumber', 'channel_number', 'number')
             number = int(number_raw) if number_raw.isdigit() else None
+            # DirecTV's own channel number, not FastChannels' guide-output number
+            # (Channel.number gets globally reassigned for M3U/guide purposes — see
+            # worker.py's _renumber — so it can't be used later to identify FAST
+            # channels; tag them instead, which survives that reassignment).
+            is_fast = number is not None and number in self._FAST_CHANNEL_NUMBER_RANGE
+            if exclude_fast and is_fast:
+                continue
             logo = _pick(row, 'logoUrl', 'logoURL', 'logo_url') or (
                 f"https://dfwfis.prod.dtvcdn.com/catalog/image/imageserver/v1/"
                 f"service/channel/{resource_id}/chlogo-clb-guide/120/90"
@@ -1537,6 +1564,12 @@ class DirectvScraper(BaseScraper):
 
             category = category_for_channel(name, None) or infer_category_from_name(name) or 'Entertainment'
             language = infer_language_from_metadata(name)
+
+            # externalListingId is DirecTV's own Gracenote/TMS station ID — confirmed
+            # against a known-correct DTV-derived M3U (tvc-guide-stationid matched
+            # exactly on every cross-checked channel). Try it before falling back to
+            # the community-maintained gracenote_map, which only covers a subset.
+            external_listing_id = _pick(row, 'externalListingId')
 
             channels.append(ChannelData(
                 source_channel_id=ccid,
@@ -1547,8 +1580,9 @@ class DirectvScraper(BaseScraper):
                 language=language,
                 stream_type='hls',
                 number=number,
-                gracenote_id=(resolve_gracenote('directv', lookup_key=ccid)
+                gracenote_id=(resolve_gracenote('directv', upstream_id=external_listing_id, lookup_key=ccid)
                               or resolve_gracenote('directv', lookup_key=f'name:{_directv_gracenote_key(name)}')),
+                tags=[self.FAST_TAG] if is_fast else [],
             ))
 
         _progress(self, 'channels', 1, 1)

--- a/app/scrapers/directv.py
+++ b/app/scrapers/directv.py
@@ -1375,15 +1375,8 @@ class DirectvScraper(BaseScraper):
                         'On = leave out free, ad-supported channels. '
                         'DirecTV Stream puts these in the 4000-4999 channel number range.'
                     )),
-        ConfigField('purge_fast_channels', 'Remove existing FAST channels immediately',
-                    field_type='toggle', default='false',
-                    help_text=(
-                        'On = when you enable the exclusion above, also delete previously-scraped 4xxx '
-                        'channels right away. Off = they stay listed and quietly age out over the next few scrapes.'
-                    )),
     ]
 
-    # Also referenced by api_sources.py's immediate-purge path.
     _FAST_CHANNEL_NUMBER_RANGE = range(4000, 5000)
     FAST_TAG = 'DirecTV FAST'
 
@@ -1539,6 +1532,7 @@ class DirectvScraper(BaseScraper):
             raise ScrapeSkipError('DirecTV Stream: could not find a channel list in the AllChannels response')
 
         exclude_fast = self._exclude_fast_channels()
+        self.excluded_channel_ids = set()
         channels: list[ChannelData] = []
 
         for row in rows:
@@ -1556,6 +1550,7 @@ class DirectvScraper(BaseScraper):
             # channels; tag them instead, which survives that reassignment).
             is_fast = number is not None and number in self._FAST_CHANNEL_NUMBER_RANGE
             if exclude_fast and is_fast:
+                self.excluded_channel_ids.add(ccid)
                 continue
             logo = _pick(row, 'logoUrl', 'logoURL', 'logo_url') or (
                 f"https://dfwfis.prod.dtvcdn.com/catalog/image/imageserver/v1/"
@@ -1565,10 +1560,9 @@ class DirectvScraper(BaseScraper):
             category = category_for_channel(name, None) or infer_category_from_name(name) or 'Entertainment'
             language = infer_language_from_metadata(name)
 
-            # externalListingId is DirecTV's own Gracenote/TMS station ID — confirmed
-            # against a known-correct DTV-derived M3U (tvc-guide-stationid matched
-            # exactly on every cross-checked channel). Try it before falling back to
-            # the community-maintained gracenote_map, which only covers a subset.
+            # Stream lineups can supply Gracenote IDs here. Satellite lineups
+            # also contain internal channel IDs; retain resolver validation and
+            # community-map fallback rather than accepting every value.
             external_listing_id = _pick(row, 'externalListingId')
 
             channels.append(ChannelData(

--- a/app/scrapers/sling.py
+++ b/app/scrapers/sling.py
@@ -79,12 +79,6 @@ class SlingScraper(BaseScraper):
                         'On = leave out free, ad-supported Freestream channels. '
                         'Only useful together with the paid account toggle above — otherwise this source scrapes nothing.'
                     )),
-        ConfigField('purge_fast_channels', 'Remove existing FAST channels immediately',
-                    field_type='toggle', default='false',
-                    help_text=(
-                        'On = when you enable the exclusion above, also delete previously-scraped Freestream '
-                        'channels right away. Off = they stay listed and quietly age out over the next few scrapes.'
-                    )),
         ConfigField('username', 'Email', placeholder='you@example.com',
                     help_text='Used by the "Sign in to Sling" button to auto-fill the sign-in form.'),
         ConfigField('password', 'Password', field_type='password', secret=True,
@@ -96,7 +90,7 @@ class SlingScraper(BaseScraper):
         'inputstream.adaptive.license_type': 'com.widevine.alpha',
     }
     channel_refresh_hours = 0    # fetch channel list every run — one summary call; avoids channel-list staleness
-    FREESTREAM_TAG = 'Sling Freestream'  # also referenced by api_sources.py's immediate-purge path
+    FREESTREAM_TAG = 'Sling Freestream'
 
     CMW_FAST = "https://p-cmwnext-fast.movetv.com"
     CMW = "https://p-cmwnext.movetv.com"
@@ -178,16 +172,22 @@ class SlingScraper(BaseScraper):
         summary_channels = payload.get("channels") or []
         channels: dict[str, ChannelData] = {}
 
-        if not self._exclude_fast_channels():
-            for item in summary_channels:
-                channel = self._channel_from_summary(item)
-                if channel is not None:
+        self.excluded_channel_ids = set()
+        exclude_fast = self._exclude_fast_channels()
+        for item in summary_channels:
+            channel = self._channel_from_summary(item)
+            if channel is not None:
+                if exclude_fast:
+                    self.excluded_channel_ids.add(channel.source_channel_id)
+                else:
                     channels[channel.source_channel_id] = channel
 
         if self._include_subscription_channels():
             for channel in self._fetch_subscription_channels():
                 channels[channel.source_channel_id] = channel
 
+        # Paid entitlement wins when the same channel appears in both lists.
+        self.excluded_channel_ids.difference_update(channels)
         result = sorted(channels.values(), key=lambda c: (c.name or "", c.source_channel_id))
         logger.info("[%s] %d channels", self.source_name, len(result))
         return result

--- a/app/scrapers/sling.py
+++ b/app/scrapers/sling.py
@@ -73,6 +73,18 @@ class SlingScraper(BaseScraper):
                         'Off = Freestream only (free, anonymous; no sign-in needed). '
                         'On = also include paid subscription channels; requires a paid Sling account.'
                     )),
+        ConfigField('exclude_fast_channels', 'Exclude FAST channels (Freestream)',
+                    field_type='toggle', default='false',
+                    help_text=(
+                        'On = leave out free, ad-supported Freestream channels. '
+                        'Only useful together with the paid account toggle above — otherwise this source scrapes nothing.'
+                    )),
+        ConfigField('purge_fast_channels', 'Remove existing FAST channels immediately',
+                    field_type='toggle', default='false',
+                    help_text=(
+                        'On = when you enable the exclusion above, also delete previously-scraped Freestream '
+                        'channels right away. Off = they stay listed and quietly age out over the next few scrapes.'
+                    )),
         ConfigField('username', 'Email', placeholder='you@example.com',
                     help_text='Used by the "Sign in to Sling" button to auto-fill the sign-in form.'),
         ConfigField('password', 'Password', field_type='password', secret=True,
@@ -84,6 +96,7 @@ class SlingScraper(BaseScraper):
         'inputstream.adaptive.license_type': 'com.widevine.alpha',
     }
     channel_refresh_hours = 0    # fetch channel list every run — one summary call; avoids channel-list staleness
+    FREESTREAM_TAG = 'Sling Freestream'  # also referenced by api_sources.py's immediate-purge path
 
     CMW_FAST = "https://p-cmwnext-fast.movetv.com"
     CMW = "https://p-cmwnext.movetv.com"
@@ -165,10 +178,11 @@ class SlingScraper(BaseScraper):
         summary_channels = payload.get("channels") or []
         channels: dict[str, ChannelData] = {}
 
-        for item in summary_channels:
-            channel = self._channel_from_summary(item)
-            if channel is not None:
-                channels[channel.source_channel_id] = channel
+        if not self._exclude_fast_channels():
+            for item in summary_channels:
+                channel = self._channel_from_summary(item)
+                if channel is not None:
+                    channels[channel.source_channel_id] = channel
 
         if self._include_subscription_channels():
             for channel in self._fetch_subscription_channels():
@@ -260,6 +274,9 @@ class SlingScraper(BaseScraper):
 
     def _include_subscription_channels(self) -> bool:
         return str(self.config.get('include_subscription_channels', '')).strip().lower() in {'1', 'true', 'yes', 'on'}
+
+    def _exclude_fast_channels(self) -> bool:
+        return str(self.config.get('exclude_fast_channels', '')).strip().lower() in {'1', 'true', 'yes', 'on'}
 
     def _oauth(self, token: str | None = None, token_secret: str | None = None):
         if OAuth1 is None:
@@ -672,7 +689,7 @@ class SlingScraper(BaseScraper):
             number=self._to_int(item.get("channel_number")),
             gracenote_id=resolve_gracenote('sling', upstream_id=item.get('gracenote_channel_id'), lookup_key=channel_guid),
             guide_key=qvt_url,
-            tags=['Sling Freestream'] if require_free else ['Sling Subscription'],
+            tags=[self.FREESTREAM_TAG] if require_free else ['Sling Subscription'],
         )
 
     def _best_summary_channel_name(self, item: dict[str, Any]) -> str | None:

--- a/app/templates/admin/sources.html
+++ b/app/templates/admin/sources.html
@@ -297,6 +297,7 @@
     .toggle-label.off { color: var(--text-muted); }
     .toggle {
       position: relative; display: inline-block; width: 44px; height: 24px; cursor: pointer;
+      flex-shrink: 0;
     }
     .toggle input { opacity: 0; width: 0; height: 0; }
     .slider {
@@ -3113,6 +3114,27 @@
     function renderDirectvConfig(sourceId, schema, values, cfg = {}) {
       const hasSession = cfg.config_complete === true || cfg.config_status === 'configured';
       const hasCreds = !!((values.username || '').trim() && (values.password || '').trim());
+      const toggleHtml = (key, fallbackLabel, fallbackHelp) => {
+        const field = schema.find(f => f.key === key);
+        const checked = ['1', 'true', 'yes', 'on'].includes(
+          String(values[key] ?? field?.default ?? '').trim().toLowerCase()
+        );
+        const label = field?.label || fallbackLabel;
+        const help = field?.help_text || fallbackHelp;
+        return `
+          <div class="field field-full">
+            <div class="config-toggle-field">
+              <div class="config-toggle-text">
+                <label for="cfg-${sourceId}-${key}">${escapeHtml(label)}</label>
+                <div class="help">${escapeHtml(help)}</div>
+              </div>
+              <label class="toggle" title="${escapeHtml(label)}">
+                <input type="checkbox" id="cfg-${sourceId}-${key}" data-key="${key}" data-secret="false"${checked ? ' checked' : ''}>
+                <span class="slider"></span>
+              </label>
+            </div>
+          </div>`;
+      };
       return `
         <div class="config-title">DirecTV Stream Settings</div>
         <div class="config-note">
@@ -3134,6 +3156,13 @@
           </div>
         </div>
 
+        <div class="fields-grid">
+          ${toggleHtml('exclude_fast_channels', 'Exclude FAST channels',
+            'On = leave out free, ad-supported channels (DirecTV Stream numbers these 4000-4999).')}
+          ${toggleHtml('purge_fast_channels', 'Remove existing FAST channels immediately',
+            'On = when you enable the exclusion above, also delete previously-scraped 4xxx channels right away.')}
+        </div>
+
         <details class="amazon-account-details" ${hasCreds ? '' : 'open'}>
           <summary>Account settings</summary>
           <div class="fields-grid" style="margin-top:0.75rem;">
@@ -3149,12 +3178,13 @@
                      value="${escapeHtml(String(values.password || ''))}" autocomplete="off">
             </div>
           </div>
-          <div class="config-actions">
-            <span class="config-status" id="config-status-${sourceId}"></span>
-            <button class="btn btn-cancel" type="button" onclick="clearConfigFields(${sourceId})">Clear</button>
-            <button class="btn btn-run" type="button" onclick="saveSourceConfig(${sourceId})">Save Account</button>
-          </div>
-        </details>`;
+        </details>
+
+        <div class="config-actions">
+          <span class="config-status" id="config-status-${sourceId}"></span>
+          <button class="btn btn-cancel" type="button" onclick="clearConfigFields(${sourceId})">Clear</button>
+          <button class="btn btn-run" type="button" onclick="saveSourceConfig(${sourceId})">Save Settings</button>
+        </div>`;
     }
 
     async function directvStartLogin(sourceId) {
@@ -3383,7 +3413,9 @@
       };
 
       const toggleField = schema.find(f => f.key === 'include_subscription_channels');
-      const otherFields = schema.filter(f => f.key !== 'include_subscription_channels');
+      const fastToggleField = schema.find(f => f.key === 'exclude_fast_channels');
+      const purgeToggleField = schema.find(f => f.key === 'purge_fast_channels');
+      const otherFields = schema.filter(f => !['include_subscription_channels', 'exclude_fast_channels', 'purge_fast_channels'].includes(f.key));
       const lastSignIn = _epochAgo(cfg && cfg.oauth_token_time);
       const lastSignInHtml = lastSignIn
         ? `<div class="help" id="sling-last-signin-${sourceId}" style="color:var(--success-soft);">✓ Last signed in successfully: ${lastSignIn}</div>`
@@ -3394,6 +3426,8 @@
         <div class="config-note">Freestream works with no sign-in needed. Turn on the toggle below to also include paid Sling subscription channels.</div>
         <div class="fields-grid">
           ${toggleField ? fieldHtml(toggleField) : ''}
+          ${fastToggleField ? fieldHtml(fastToggleField) : ''}
+          ${purgeToggleField ? fieldHtml(purgeToggleField) : ''}
           <div class="field field-full" style="margin:0.25rem 0 0.5rem;">
             <button class="btn btn-run" type="button" onclick="openSlingLoginModal(${sourceId})">Sign in to Sling</button>
             <div class="help">Opens a real Sling sign-in page right here — solve the captcha yourself if it's shown, and FastChannels saves the resulting session automatically. No credentials are typed by FastChannels.</div>

--- a/app/templates/admin/sources.html
+++ b/app/templates/admin/sources.html
@@ -3159,8 +3159,6 @@
         <div class="fields-grid">
           ${toggleHtml('exclude_fast_channels', 'Exclude FAST channels',
             'On = leave out free, ad-supported channels (DirecTV Stream numbers these 4000-4999).')}
-          ${toggleHtml('purge_fast_channels', 'Remove existing FAST channels immediately',
-            'On = when you enable the exclusion above, also delete previously-scraped 4xxx channels right away.')}
         </div>
 
         <details class="amazon-account-details" ${hasCreds ? '' : 'open'}>
@@ -3414,8 +3412,7 @@
 
       const toggleField = schema.find(f => f.key === 'include_subscription_channels');
       const fastToggleField = schema.find(f => f.key === 'exclude_fast_channels');
-      const purgeToggleField = schema.find(f => f.key === 'purge_fast_channels');
-      const otherFields = schema.filter(f => !['include_subscription_channels', 'exclude_fast_channels', 'purge_fast_channels'].includes(f.key));
+      const otherFields = schema.filter(f => !['include_subscription_channels', 'exclude_fast_channels'].includes(f.key));
       const lastSignIn = _epochAgo(cfg && cfg.oauth_token_time);
       const lastSignInHtml = lastSignIn
         ? `<div class="help" id="sling-last-signin-${sourceId}" style="color:var(--success-soft);">✓ Last signed in successfully: ${lastSignIn}</div>`
@@ -3427,7 +3424,6 @@
         <div class="fields-grid">
           ${toggleField ? fieldHtml(toggleField) : ''}
           ${fastToggleField ? fieldHtml(fastToggleField) : ''}
-          ${purgeToggleField ? fieldHtml(purgeToggleField) : ''}
           <div class="field field-full" style="margin:0.25rem 0 0.5rem;">
             <button class="btn btn-run" type="button" onclick="openSlingLoginModal(${sourceId})">Sign in to Sling</button>
             <div class="help">Opens a real Sling sign-in page right here — solve the captcha yourself if it's shown, and FastChannels saves the resulting session automatically. No credentials are typed by FastChannels.</div>

--- a/app/worker.py
+++ b/app/worker.py
@@ -505,6 +505,7 @@ def run_scraper(source_name: str, force_full: bool = False):
                                 rehome_by_guide_key=getattr(scraper, 'rehome_by_guide_key', False),
                                 allow_suspicious_collapse=getattr(scraper, 'allow_suspicious_channel_collapse', False),
                                 pinned_channel_ids=getattr(scraper, 'pinned_channel_ids', frozenset()),
+                                excluded_channel_ids=getattr(scraper, 'excluded_channel_ids', frozenset()),
                             )
                         # Persist scraper config/cache FIRST. persist_*() call
                         # db.session.expire_all(), which DISCARDS unflushed attribute
@@ -2434,7 +2435,8 @@ def _sync_intrinsic_drm_bridge(source) -> None:
 
 def _upsert_channels(source, channel_data_list, gracenote_auto_fill: bool = True, active_geos: set | None = None,
                      miss_threshold: int = _CHANNEL_MISS_THRESHOLD, rehome_by_guide_key: bool = False,
-                     allow_suspicious_collapse: bool = False, pinned_channel_ids: frozenset = frozenset()):
+                     allow_suspicious_collapse: bool = False, pinned_channel_ids: frozenset = frozenset(),
+                     excluded_channel_ids: frozenset = frozenset()):
     existing = {ch.source_channel_id: ch for ch in source.channels.all()}
 
     # Build a guide_key → channel index so we can re-use an existing DB row
@@ -2615,6 +2617,18 @@ def _upsert_channels(source, channel_data_list, gracenote_auto_fill: bool = True
     seen = {cd.source_channel_id for cd in channel_data_list}
     existing_active_ids = {ch_id for ch_id, ch in existing.items() if ch.is_active}
     missing_active_ids = existing_active_ids - seen
+    # Explicit scraper filters are not missing upstream channels. Identify them
+    # from the fetched inventory, including rows imported before tags existed.
+    filtered_ids = (set(excluded_channel_ids) & set(existing)) - seen
+    for ch_id in filtered_ids:
+        ch = existing[ch_id]
+        if ch.is_active:
+            ch.went_inactive_at = seen_at
+        ch.is_active = False
+        # Keep user settings and refresh last_seen_at while upstream still
+        # lists the channel, so orphan cleanup does not erase filtered rows.
+        ch.last_seen_at = seen_at
+        ch.missed_scrapes = 0
 
     # Channels from regions the scraper no longer has configured are intentionally
     # absent — exclude them from the collapse ratio so a region removal doesn't
@@ -2626,13 +2640,13 @@ def _upsert_channels(source, channel_data_list, gracenote_auto_fill: bool = True
         }
     else:
         region_removed_ids = set()
-    missing_active_organic = missing_active_ids - region_removed_ids
+    missing_active_organic = missing_active_ids - region_removed_ids - filtered_ids
 
     # Guard against upstream/parser glitches returning a tiny partial lineup.
     # If we previously had a substantial active set and the new fetch would
     # deactivate most of it, keep the old rows active and log loudly instead
     # of collapsing the source to a handful of channels.
-    organic_existing = len(existing_active_ids) - len(region_removed_ids)
+    organic_existing = len(existing_active_ids - region_removed_ids - filtered_ids)
     if organic_existing > 0:
         missing_ratio = len(missing_active_organic) / max(organic_existing, 1)
     else:
@@ -2672,7 +2686,7 @@ def _upsert_channels(source, channel_data_list, gracenote_auto_fill: bool = True
         )
     else:
         for ch_id, ch in existing.items():
-            if ch_id not in seen and ch_id not in region_removed_ids:
+            if ch_id not in seen and ch_id not in region_removed_ids and ch_id not in filtered_ids:
                 if not ch.is_active:
                     continue  # already inactive — don't touch to avoid bumping updated_at
                 next_missed = (ch.missed_scrapes or 0) + 1


### PR DESCRIPTION
Adds an “Exclude FAST channels” setting for DIRECTV and Sling. Saving a changed filter queues a full channel scrape. DIRECTV identifies FAST entries using the provider's original 4000–4999 channel numbers; Sling identifies them from its Freestream summary.

The scrapers report intentionally excluded channel IDs to reconciliation. Existing matching rows become inactive after a successful scrape, preserving their user settings and requiring no pre-existing FAST tag. Filtered entries are excluded from the lineup-collapse calculation; unexpected upstream losses retain the existing safeguard. Re-enabling inclusion restores discovered channels through normal reconciliation. There is no immediate-deletion toggle or FAST deletion path.

Changing Sling's FAST filter preserves its saved OAuth session. When a channel appears in both the free and paid inventories, the paid entry remains included.

DIRECTV also passes externalListingId through the existing Gracenote validator before falling back to community mappings. This field can contain internal channel IDs on satellite accounts, so it must not be treated as universally authoritative. Satellite live-stream eligibility filtering is separate follow-up work.

Validation: focused checks with mocked provider responses and isolated SQLite passed for DIRECTV provider-number filtering and toggle reversal, Sling free/paid overlap, deactivation of previously untagged rows without deletion, preservation of user settings on return, protection against unexpected lineup collapse, and saved OAuth preservation plus forced full scrape on config save. Python/Jinja syntax and git diff whitespace checks passed. No live playback or deployed UI testing was performed.
