### PR TITLE
Filter non-streamable DIRECTV satellite channels

### DIFF
--- a/app/scrapers/directv.py
+++ b/app/scrapers/directv.py
@@ -1533,6 +1533,7 @@ class DirectvScraper(BaseScraper):
 
         exclude_fast = self._exclude_fast_channels()
         self.excluded_channel_ids = set()
+        non_streamable = 0
         channels: list[ChannelData] = []
 
         for row in rows:
@@ -1540,6 +1541,16 @@ class DirectvScraper(BaseScraper):
             resource_id = _pick(row, 'resourceId', 'resourceID', 'resource_id', 'guid')
             name = _pick(row, 'channelName', 'name', 'displayName', 'title')
             if not ccid or not resource_id or not name:
+                continue
+
+            # Satellite lineups include receiver-only entries alongside their
+            # streamable variants. Trust only an explicit JSON false: missing
+            # metadata must preserve compatibility with other account lineups.
+            augmentation = row.get('augmentation')
+            constraints = augmentation.get('constraints') if isinstance(augmentation, dict) else None
+            if isinstance(constraints, dict) and constraints.get('isLiveStreamEnabled') is False:
+                self.excluded_channel_ids.add(ccid)
+                non_streamable += 1
                 continue
 
             number_raw = _pick(row, 'channelNumber', 'channel_number', 'number')
@@ -1579,6 +1590,10 @@ class DirectvScraper(BaseScraper):
                 tags=[self.FAST_TAG] if is_fast else [],
             ))
 
+        logger.info(
+            '[directv] channel eligibility: upstream=%d included=%d non_streamable=%d excluded=%d',
+            len(rows), len(channels), non_streamable, len(self.excluded_channel_ids),
+        )
         _progress(self, 'channels', 1, 1)
         return channels
 


### PR DESCRIPTION
DIRECTV satellite lineups include receiver-only channels alongside streamable variants. Previously all entries were imported; for example, A&E SD (265) failed authorization while A&E HD (8223) streamed through the existing API.

Filter entries explicitly marked augmentation.constraints.isLiveStreamEnabled=false before returning channels from the scraper. Report those IDs through the existing exclusion reconciliation so previously imported entries become inactive without deleting their settings. Keep true, missing, and unrecognized eligibility values, and apply the optional FAST filter independently. No account-type setting or separate scraper is needed.

Validation: a read-only dry run of the patched parser against the configured satellite lineup included 357 of 631 channels and excluded 274. A&E, CNN, and ESPN retained their streamable HD entries and excluded their non-streamable SD entries. Mocked-response checks covered strict boolean handling, missing/malformed metadata, streamable SD, FAST-filter composition, and eligibility reversal. Isolated SQLite regression checks passed for settings preservation, reactivation, and collapse protection. Python syntax and git diff checks passed.

Not deployed. This filters declared eligibility; it does not guarantee entitlement or successful DRM playback for every remaining channel.
