### PR TITLE
Added FC Player detection and version column to Check Tuner Authorizations

### DIFF
--- a/app/fc_player_bridge.py
+++ b/app/fc_player_bridge.py
@@ -327,9 +327,8 @@ def _device_os_and_sleep(address: str) -> dict:
         'player_version': None,    # versionName string when installed
     }
     # One remote shell, newline-separated, in a fixed order we can index back out.
-    # The player dumpsys goes last and unbounded — we scrape versionName/versionCode
-    # out of the whole blob with a regex rather than by line index, so its multi-line
-    # output can't shift the six fixed fields above it.
+    # The player dumpsys goes last so its multi-line output cannot shift the
+    # OS, sleep, and current-user fields above it.
     remote = (
         'getprop ro.build.version.release; '
         'getprop ro.product.manufacturer; '
@@ -337,6 +336,7 @@ def _device_os_and_sleep(address: str) -> dict:
         'getprop ro.build.version.name; '
         'settings get secure sleep_timeout; '
         'settings get system screen_off_timeout; '
+        'am get-current-user; '
         'dumpsys package com.fastchannels.player'
     )
     try:
@@ -351,21 +351,30 @@ def _device_os_and_sleep(address: str) -> dict:
 
     stdout = res.stdout or ''
     lines = [ln.strip() for ln in stdout.splitlines()]
-    lines += [''] * (6 - len(lines))
-    release, manufacturer, fireos, build_name, sleep_timeout, screen_off = lines[:6]
+    lines += [''] * (7 - len(lines))
+    release, manufacturer, fireos, build_name, sleep_timeout, screen_off, current_user = lines[:7]
+    package_info = '\n'.join(lines[7:])
 
-    # `dumpsys package` only prints a versionName/versionCode block for a package
-    # that's actually installed, so a hit here doubles as the "is it installed?"
-    # answer. A missing package prints "Unable to find package:" and matches neither.
-    version_name = re.search(r'\bversionName=(\S+)', stdout)
-    version_code = re.search(r'\bversionCode=(\d+)', stdout)
-    if version_name or version_code:
-        out['player_installed'] = True
-        out['player_version'] = version_name.group(1) if version_name else f'code {version_code.group(1)}'
-    elif 'Unable to find package' in stdout:
+    # Version metadata is device-wide and can survive a per-user uninstall.
+    # Playback launches for the foreground user, so require that user's explicit
+    # installed flag before showing a version as confirmation of installation.
+    if 'Unable to find package' in package_info:
         out['player_installed'] = False
-    # else: dumpsys gave us nothing usable — leave player_installed None (Unknown)
-    # rather than guessing "not installed".
+    elif re.fullmatch(r'[0-9]+', current_user):
+        user_state = re.search(
+            rf'^User {current_user}:[^\n]*\binstalled=(true|false)\b',
+            package_info, re.MULTILINE,
+        )
+        if user_state:
+            out['player_installed'] = user_state.group(1) == 'true'
+            if out['player_installed']:
+                version_name = re.search(r'\bversionName=(\S+)', package_info)
+                version_code = re.search(r'\bversionCode=(\d+)', package_info)
+                if version_name:
+                    out['player_version'] = version_name.group(1)
+                elif version_code:
+                    out['player_version'] = f'code {version_code.group(1)}'
+    # Missing user or installation state stays Unknown, even if a version exists.
 
     fire = 'amazon' in manufacturer.lower() or bool(fireos) or 'fire os' in build_name.lower()
     out['is_fire_os'] = fire
@@ -444,8 +453,8 @@ def verify_ah4c_tuners() -> list[dict]:
     OS), whether auto-sleep is turned off — a stick that dozes off mid-session
     is a common ah4c-path failure, so "no signal" is easier to chase down when the
     table already says the display sleep timer is still armed — and the installed
-    FastChannels Player version (its presence confirms the app is installed at
-    all; ah4c can drive a stick that never got the player sideloaded)."""
+    FastChannels Player version after confirming installation for the active
+    Android user; ah4c can drive a stick that never got the player sideloaded."""
     results: list[dict] = []
     for idx, ip in enumerate(ah4c_tuner_ips(), start=1):
         # ah4c stores TUNERn_IP as a bare host or host:port; the container's adb

--- a/app/fc_player_bridge.py
+++ b/app/fc_player_bridge.py
@@ -323,15 +323,21 @@ def _device_os_and_sleep(address: str) -> dict:
         'is_fire_os': False,
         'sleep_disabled': None,   # True / False / None (unknown)
         'sleep_detail': '',
+        'player_installed': None,  # True / False / None (unknown)
+        'player_version': None,    # versionName string when installed
     }
     # One remote shell, newline-separated, in a fixed order we can index back out.
+    # The player dumpsys goes last and unbounded — we scrape versionName/versionCode
+    # out of the whole blob with a regex rather than by line index, so its multi-line
+    # output can't shift the six fixed fields above it.
     remote = (
         'getprop ro.build.version.release; '
         'getprop ro.product.manufacturer; '
         'getprop ro.build.version.fireos; '
         'getprop ro.build.version.name; '
         'settings get secure sleep_timeout; '
-        'settings get system screen_off_timeout'
+        'settings get system screen_off_timeout; '
+        'dumpsys package com.fastchannels.player'
     )
     try:
         res = subprocess.run(
@@ -343,9 +349,23 @@ def _device_os_and_sleep(address: str) -> dict:
     if res.returncode != 0:
         return out
 
-    lines = [ln.strip() for ln in (res.stdout or '').splitlines()]
+    stdout = res.stdout or ''
+    lines = [ln.strip() for ln in stdout.splitlines()]
     lines += [''] * (6 - len(lines))
     release, manufacturer, fireos, build_name, sleep_timeout, screen_off = lines[:6]
+
+    # `dumpsys package` only prints a versionName/versionCode block for a package
+    # that's actually installed, so a hit here doubles as the "is it installed?"
+    # answer. A missing package prints "Unable to find package:" and matches neither.
+    version_name = re.search(r'\bversionName=(\S+)', stdout)
+    version_code = re.search(r'\bversionCode=(\d+)', stdout)
+    if version_name or version_code:
+        out['player_installed'] = True
+        out['player_version'] = version_name.group(1) if version_name else f'code {version_code.group(1)}'
+    elif 'Unable to find package' in stdout:
+        out['player_installed'] = False
+    # else: dumpsys gave us nothing usable — leave player_installed None (Unknown)
+    # rather than guessing "not installed".
 
     fire = 'amazon' in manufacturer.lower() or bool(fireos) or 'fire os' in build_name.lower()
     out['is_fire_os'] = fire
@@ -421,9 +441,11 @@ def verify_ah4c_tuners() -> list[dict]:
     surfaces.
 
     For tuners that are authorized, it also reports the device OS (flagging Fire
-    OS) and whether auto-sleep is turned off — a stick that dozes off mid-session
+    OS), whether auto-sleep is turned off — a stick that dozes off mid-session
     is a common ah4c-path failure, so "no signal" is easier to chase down when the
-    table already says the display sleep timer is still armed."""
+    table already says the display sleep timer is still armed — and the installed
+    FastChannels Player version (its presence confirms the app is installed at
+    all; ah4c can drive a stick that never got the player sideloaded)."""
     results: list[dict] = []
     for idx, ip in enumerate(ah4c_tuner_ips(), start=1):
         # ah4c stores TUNERn_IP as a bare host or host:port; the container's adb
@@ -441,6 +463,8 @@ def verify_ah4c_tuners() -> list[dict]:
             'is_fire_os': False,
             'sleep_disabled': None,
             'sleep_detail': '',
+            'player_installed': None,
+            'player_version': None,
         }
         if state == 'device':
             row.update(_device_os_and_sleep(address))

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -366,7 +366,7 @@ function renderAh4cTuners(tuners) {
   const table = document.createElement('table');
   table.className = 'ah4c-tuners-table';
   const head = table.createTHead().insertRow();
-  ['ah4c tuner', 'TUNERx_IP', 'Authorized in FastChannels', 'Android / Fire OS', 'Sleep disabled'].forEach((label) => {
+  ['ah4c tuner', 'TUNERx_IP', 'Authorized in FastChannels', 'Android / Fire OS', 'Sleep disabled', 'FC Player'].forEach((label) => {
     const th = document.createElement('th');
     th.textContent = label;
     // Keep the literal env-var name as-is; the other headers get uppercased by CSS.
@@ -421,6 +421,17 @@ function renderAh4cTuners(tuners) {
       addBadge(sleepCell, '✕ Still armed', 'warn', t.sleep_detail);
     } else {
       addBadge(sleepCell, '? Unknown', 'warn', t.sleep_detail);
+    }
+
+    const playerCell = row.insertCell();
+    if (t.state !== 'device') {
+      playerCell.textContent = '—';
+    } else if (t.player_installed === true) {
+      addBadge(playerCell, '✓ ' + (t.player_version || 'Installed'), 'ok');
+    } else if (t.player_installed === false) {
+      addBadge(playerCell, '✕ Not installed', 'warn');
+    } else {
+      addBadge(playerCell, '? Unknown', 'warn');
     }
   });
   box.appendChild(table);

--- a/docs/fc-player-setup.md
+++ b/docs/fc-player-setup.md
@@ -351,9 +351,11 @@ build or maintain on the ah4c side.
      prompt on that TV). For authorized tuners the table also shows the device
      OS (flagging Fire OS), whether auto-sleep is turned off, and the installed
      **FC Player** version — a version number there confirms FastChannels Player
-     is installed on that stick, and **Not installed** means ah4c can reach the
-     device but the player was never sideloaded onto it (install it with the
-     button on the HDMI Capture card, or the manual APK fallback). A stick whose
+     is installed for the active Android user on that stick. **Not installed**
+     means the player is absent for that user, even if it exists for another
+     user (install it with the button on the HDMI Capture card, or the manual
+     APK fallback). **Unknown** means the device did not report enough information
+     to confirm installation for the active user. A stick whose
      display sleep timer is still armed will drop to "no signal" partway through
      a session. Disable sleep on the device (Fire TV: **Settings → Display &
      Sounds → Display → Sleep → Never**; Android TV: the screensaver / sleep

--- a/docs/fc-player-setup.md
+++ b/docs/fc-player-setup.md
@@ -349,7 +349,11 @@ build or maintain on the ah4c side.
      a tuner ah4c already drives can still show **Not authorized** here — fix it
      the same way as any other unapproved key (trigger an action, approve the
      prompt on that TV). For authorized tuners the table also shows the device
-     OS (flagging Fire OS) and whether auto-sleep is turned off — a stick whose
+     OS (flagging Fire OS), whether auto-sleep is turned off, and the installed
+     **FC Player** version — a version number there confirms FastChannels Player
+     is installed on that stick, and **Not installed** means ah4c can reach the
+     device but the player was never sideloaded onto it (install it with the
+     button on the HDMI Capture card, or the manual APK fallback). A stick whose
      display sleep timer is still armed will drop to "no signal" partway through
      a session. Disable sleep on the device (Fire TV: **Settings → Display &
      Sounds → Display → Sleep → Never**; Android TV: the screensaver / sleep


### PR DESCRIPTION
[app/static/js/settings.js](vscode-webview://1fam9q4hn3pllfg9ur94ujq403ddqoi4214h68i5bc6d7r5kclce/app/static/js/settings.js) — renderAh4cTuners() gets a sixth column, FC Player:

authorized + installed → ✓ 5.1.0 (green)
authorized + missing → ✕ Not installed (amber)
authorized + couldn't tell → ? Unknown (amber)
not authorized → — (same as the OS / Sleep columns)
[docs/fc-player-setup.md](vscode-webview://1fam9q4hn3pllfg9ur94ujq403ddqoi4214h68i5bc6d7r5kclce/docs/fc-player-setup.md) — updated the "Check tuner authorization(s)" description to mention the new column and what Not installed means (ah4c can reach the stick but the player was never sideloaded).

The version string doubles as the "is it installed" confirmation you asked for — a number in that cell means the app is present. It's the on-device version only; there's no comparison to "latest" (that would need the bundled-APK-version work from the earlier option).

<img width="867" height="683" alt="Screenshot 2026-09-06 at 19-20-39 FastChannels - Organizr V2" src="https://github.com/user-attachments/assets/6271a1b4-d78b-429f-ae0e-18b1d149dcf6" />
